### PR TITLE
MISC: Upgrade Expo and other dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,10 +51,10 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/aes-js": "^3.1.4",
-        "@types/react": "^19.2.2",
+        "@types/react": "^19.1.10",
         "eslint": "^9.25.0",
-        "eslint-config-expo": "~9.2.0",
-        "typescript": "~5.8.3"
+        "eslint-config-expo": "^10.0.0",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -3527,9 +3527,9 @@
       "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
     },
     "node_modules/@types/react": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
-      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "version": "19.1.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
+      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5890,15 +5890,15 @@
       }
     },
     "node_modules/eslint-config-expo": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-expo/-/eslint-config-expo-9.2.0.tgz",
-      "integrity": "sha512-TQgmSx+2mRM7qUS0hB5kTDrHcSC35rA1UzOSgK5YRLmSkSMlKLmXkUrhwOpnyo9D/nHdf4ERRAySRYxgA6dlrw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-expo/-/eslint-config-expo-10.0.0.tgz",
+      "integrity": "sha512-/XC/DvniUWTzU7Ypb/cLDhDD4DXqEio4lug1ObD/oQ9Hcx3OVOR8Mkp4u6U4iGoZSJyIQmIk3WVHe/P1NYUXKw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
         "eslint-import-resolver-typescript": "^3.6.3",
-        "eslint-plugin-expo": "^0.1.4",
+        "eslint-plugin-expo": "^1.0.0",
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
@@ -6001,9 +6001,9 @@
       }
     },
     "node_modules/eslint-plugin-expo": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-expo/-/eslint-plugin-expo-0.1.4.tgz",
-      "integrity": "sha512-YA7yiMacQbLJySuyJA0Eb5V65obqp6fVOWtw1JdYDRWC5MeToPrnNvhGDpk01Bv3Vm4ownuzUfvi89MXi1d6cg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-expo/-/eslint-plugin-expo-1.0.0.tgz",
+      "integrity": "sha512-qLtunR+cNFtC+jwYCBia5c/PJurMjSLMOV78KrEOyQK02ohZapU4dCFFnS2hfrJuw0zxfsjVkjqg3QBqi933QA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "^8.29.1",
@@ -12438,9 +12438,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/aes-js": "^3.1.4",
-    "@types/react": "^19.2.2",
+    "@types/react": "^19.1.10",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0",
-    "typescript": "~5.8.3"
+    "eslint-config-expo": "^10.0.0",
+    "typescript": "^5.9.2"
   },
   "private": true
 }


### PR DESCRIPTION
# What
- Upgrade Expo to 54.0.20 to allow physical builds of the application in testing
  - Upgrade related dependencies, bringing out-of-date package warnings down to 3
- Resolves open issue #19 

# Look
iOS Simulator
<img width="2340" height="2532" alt="imagemerge" src="https://github.com/user-attachments/assets/0eb4f826-76e6-4854-b195-d8bf1c7b5dfc" />

Physical iOS Device
![78330359318__868091F9-59DC-4D62-A73B-0E82755AE542](https://github.com/user-attachments/assets/12a7cd9d-fff9-4254-a5aa-50d77b210167)

# Jira Link
[Link](https://simple-baby.atlassian.net/browse/KAN-16)