### PR TITLE
MISC: Fix null encryption key issue

### DIFF
--- a/library/supabase-client.ts
+++ b/library/supabase-client.ts
@@ -2,8 +2,10 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient } from "@supabase/supabase-js";
 import * as aesjs from "aes-js";
 import * as SecureStore from "expo-secure-store";
+import * as ExpoCrypto from "expo-crypto";
 import "react-native-get-random-values";
 import "react-native-url-polyfill/auto";
+import { Buffer } from "buffer"; 
 
 // https://stackoverflow.com/questions/76389249/provided-value-to-securestore-is-larger-than-2048-bytes-while-trying-to-store
 
@@ -71,16 +73,27 @@ class LargeSecureStore {
   }
 }
 
-// Define a constant key name
+/**
+ * Generate and persist a new 32-byte (256-bit) key as hex.
+ */
+async function createEncryptionKey(): Promise<string> {
+  const bytes = await ExpoCrypto.getRandomBytesAsync(32);       // 32 bytes = 256-bit
+  const hex = Buffer.from(bytes).toString("hex");               // store as hex string
+  await SecureStore.setItemAsync(ENCRYPTION_KEY_NAME, hex);
+  return hex;
+}
+
+// Constant key name (for current local development)
 const ENCRYPTION_KEY_NAME = "ENCRYPTION_KEY";
 
 /**
  * Retrieves the stored encryption key.
  */
 export const getEncryptionKey = async (): Promise<string | null> => {
-  console.log("🔍 Retrieving Encryption Key...");
-  const key = await SecureStore.getItemAsync(ENCRYPTION_KEY_NAME);
-  console.log("🔑 Retrieved Key:", key);
+  let key = await SecureStore.getItemAsync(ENCRYPTION_KEY_NAME);
+  if (!key) {
+    key = await createEncryptionKey();
+  }
   return key;
 };
 


### PR DESCRIPTION
# What
- Add a function to create an encryption key, to fix a bug creating null encryption keys that prevented logging data in the app
  - Previously, there was no function or call to create an encryption key locally. So, whenever you would attempt to log something in the app, the action would fail due to the encryption key being null
- Removes `console.log()` statement that printed the encryption key

# Look
<img width="2340" height="2532" alt="image (3)" src="https://github.com/user-attachments/assets/da30d8be-3591-415f-a467-1b12d61f6284" />

# Jira Ticket
- N/A