### PR TITLE
Fix for Trends/Logs Tab Sizing

### DIFF
--- a/app/(tabs)/trends.tsx
+++ b/app/(tabs)/trends.tsx
@@ -1,6 +1,7 @@
 import { Href, router } from 'expo-router';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
 import React from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type Button = {
     label: string
@@ -10,6 +11,9 @@ type Button = {
 }
 
 export default function Tab() {
+
+    const insets = useSafeAreaInsets();
+
     const bars: Button[] = [
         { label: 'Sleep Logs', icon: '🌙', link: '/(logs)/sleep-log', testID: "trends-Sleep-button"},
         { label: 'Feeding Logs', icon: '🍽️', link: '/(logs)/feeding-logs', testID: "trends-Feeding-button"},
@@ -20,26 +24,33 @@ export default function Tab() {
     ];
 
     return (
-        <View className='main-container flex-col justify-center gap-4'>
-            {bars.map((bars, key) => (
-                <TouchableOpacity
-                    onPress={() => router.push(bars.link)}
-                    className='group'
-                    key={key}
-                    testID={bars.testID}
-                >
-                    <View className='tracker-bar'>
-                        <View className='flex-row justify-center items-center gap-4'>
-                            <Text className='text-[3rem] scale-100 '>
-                                {bars.icon}
-                            </Text>
-                            <Text className='tracker-bar-label'>
-                                {bars.label}
-                            </Text>
-                        </View>
-                    </View>
-                </TouchableOpacity>
-            ))}
-        </View>
+            <View
+                className='main-container justify-between'
+                style={{ paddingBottom: insets.bottom }}
+            >
+            <ScrollView>
+                <View className='main-container flex-col justify-center gap-4'>
+                    {bars.map((bars, key) => (
+                        <TouchableOpacity
+                            onPress={() => router.push(bars.link)}
+                            className='group'
+                            key={key}
+                            testID={bars.testID}
+                        >
+                            <View className='tracker-bar'>
+                                <View className='flex-row justify-center items-center gap-4'>
+                                    <Text className='text-[3rem] scale-100 '>
+                                        {bars.icon}
+                                    </Text>
+                                    <Text className='tracker-bar-label'>
+                                        {bars.label}
+                                    </Text>
+                                </View>
+                            </View>
+                        </TouchableOpacity>
+                    ))}
+                </View>
+                </ScrollView>
+            </View>
     );
 }


### PR DESCRIPTION
# What
- Fixes the trends tab so that for small screens it allows you to scroll and see each trend button in full.
- Also fixes the trend tab for larger screens so that the trend tab doesn't leave a large empty gray space beneath the buttons.

# Look
<img width="357" height="542" alt="image" src="https://github.com/user-attachments/assets/74109ccf-e6ea-4f0f-9c1a-9557561a527f" />
<img width="309" height="593" alt="image" src="https://github.com/user-attachments/assets/42a8602f-5102-4eda-8f5c-d0b7935f3168" />



# How to Test
- Load SimpleBaby on a small device ( For example: 720 x 1280, 320 dpi)
- Navigate to the trends tab and observe that you scroll through the different buttons
- Load SimpleBaby on a larger device ( For example: 1080 x 2400, 420 dpi)
- Navigate to the trends tab and observe that there's no grey box underneath the log buttons.

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-111)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
