### PR TITLE
bugfix: sleep tracker update time picker button

### DIFF
--- a/components/manual-entry-sleep.tsx
+++ b/components/manual-entry-sleep.tsx
@@ -71,6 +71,7 @@ export default function ManualEntry({
                             setEndDate(selectedDate);
                         }
                     }
+                    setShowIOSPicker(false);
                 },
                 mode: 'time',
                 is24Hour: false,


### PR DESCRIPTION
# What
- Added line to update time picker (android) button when closing popup in sleep tracker

# Look
<img width="387" height="897" alt="image" src="https://github.com/user-attachments/assets/b2569a46-0caf-448e-b735-23857542e4cf" />

# How to Test
- Checkout this branch, and open with expo on android
- Navigate to the sleep tracker page
- Open either the start or end manual time entry pop-ups
- Close the pop-up by pressing "cancel", "ok" or pressing outside of the pop up
- The button pressed to show the pop up should revert to saying "Choose"

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-128)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
