### PR TITLE
BUG: Fix nursing log decryption errors

### DIFF
--- a/app/(trackers)/nursing.tsx
+++ b/app/(trackers)/nursing.tsx
@@ -77,12 +77,15 @@ export default function Nursing() {
             return { success: false, error };
         }
 
+        const normalizedLeftAmount = leftAmount.trim() === '' ? '0' : leftAmount.trim();
+        const normalizedRightAmount = rightAmount.trim() === '' ? '0' : rightAmount.trim();
+
         return await createNursingLog(
             childId,
             leftDuration,
             rightDuration,
-            leftAmount.trim(),
-            rightAmount.trim(),
+            normalizedLeftAmount,
+            normalizedRightAmount,
             note,
         );
     };


### PR DESCRIPTION
# What
- Previously, if the user submitted an empty string for a left or right amount in the Nursing logs, that field would not get decrypted properly when viewing the log later
- Updates `nursing.tsx` to check for an empty string, and submit a "0" in its place instead to prevent null decryption issues

# Look
BEFORE:
![Simulator Screen Recording - iPhone 16e - 2026-02-05 at 13 03 38](https://github.com/user-attachments/assets/83cfcff0-959d-4dc0-81ed-852734b0020c)

AFTER:
![Simulator Screen Recording - iPhone 16e - 2026-02-05 at 13 04 39](https://github.com/user-attachments/assets/902a20d3-e493-42c0-9048-427fcdadadf2)

# How to Test
- Checkout this branch
- Build and log into the app
- Go to the nursing log tracker
- Submit a log with just one of the left/right amounts filled out, leaving the other blank
- Then check the Nursing log viewer to ensure that a "0" appears for the blank field and not a decryption failure

# Jira Ticket
- N/A

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
