### PR TITLE
[KAN 142] Fixed Welcome Message Issue

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -125,7 +125,7 @@ export default function MainTab() {
                             intensity={10}
                             className='grow items-center justify-center'
                         >
-                            <View className='p-8 h-[50%] w-[80%] bg-white dark:bg-black rounded-3xl border-[1px] border-gray-300 dark:border-gray-600'>
+                            <View className='p-8 w-[80%] bg-white dark:bg-black rounded-3xl border-[1px] border-gray-300 dark:border-gray-600'>
                                 <View className='mb-5'>
                                     <Text className='subheading font-bold mb-6'>
                                         Welcome to SimpleBaby
@@ -140,7 +140,7 @@ export default function MainTab() {
                                             Child Name
                                         </Text>
                                         <TextInput
-                                            className='text-input'
+                                            className='text-input mb-4'
                                             placeholder='Enter a name to start tracking'
                                             value={childName}
                                             onChangeText={setChildName}


### PR DESCRIPTION
The issue was caused by the View element's height being set to 50%, so when the keyboard appeared, the amount of space that was considered 50% changed

# What
When opening the keyboard on the welcome screen, the items shift and no longer have a proper background or spacing

# Look
<img width="250" height="2277" alt="image" src="https://github.com/user-attachments/assets/52e36c54-5361-4cfc-ad53-7ea9ef9c2c91" />
<img width="250" height="2274" alt="image" src="https://github.com/user-attachments/assets/eb066f0d-66a2-4656-855f-2f44e96d519d" />




# How to Test
- Start the app with expo
- Sign up with new account information
- After signing in, confirm that the white background on the welcome message stays consistent regardless if the keyboard is open or not

# Jira Ticket
[KAN 142: Fix Welcome Message Bug](https://simple-baby.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-142)