### PR TITLE
KAN-154: Fix duplicate logging bug

### DIFF
--- a/app/(trackers)/diaper.tsx
+++ b/app/(trackers)/diaper.tsx
@@ -128,17 +128,14 @@ export default function Diaper() {
 		if (isSaving) return;
 		if (consistency && amount) {
 			setIsSaving(true);
-			try {
-				const result = await saveDiaperLog();
-				if (result.success) {
-					router.replace("/(tabs)");
-					Alert.alert("Diaper log saved successfully!");
-				} else {
-					Alert.alert(`Failed to save diaper log: ${result.error}`);
-				}
-			} finally {
-				setIsSaving(false);
+			const result = await saveDiaperLog();
+			if (result.success) {
+				router.replace("/(tabs)");
+				Alert.alert("Diaper log saved successfully!");
+			} else {
+				Alert.alert(`Failed to save diaper log: ${result.error}`);
 			}
+			setIsSaving(false);
 		} else {
 			const missingFields = [];
 			if (!consistency) missingFields.push("consistency");

--- a/app/(trackers)/feeding.tsx
+++ b/app/(trackers)/feeding.tsx
@@ -130,17 +130,14 @@ export default function Feeding() {
 		if (isSaving) return;
 		if (category && itemName && amount) {
 			setIsSaving(true);
-			try {
-				const result = await saveFeedingLog();
-				if (result.success) {
-					router.replace("/(tabs)");
-					Alert.alert("Feeding log saved successfully!");
-				} else {
-					Alert.alert(`Failed to save feeding log: ${result.error}`);
-				}
-			} finally {
-				setIsSaving(false);
+			const result = await saveFeedingLog();
+			if (result.success) {
+				router.replace("/(tabs)");
+				Alert.alert("Feeding log saved successfully!");
+			} else {
+				Alert.alert(`Failed to save feeding log: ${result.error}`);
 			}
+			setIsSaving(false);
 		} else {
 			const missingFields = [];
 			if (!category) missingFields.push("category");

--- a/app/(trackers)/health.tsx
+++ b/app/(trackers)/health.tsx
@@ -241,22 +241,19 @@ export default function Health() {
 		if (isSaving) return;
 		
 		setIsSaving(true);
-		try {
-			const result = await saveHealthLog();
-			if (result.success) {
-				router.replace("/(tabs)");
-				Alert.alert("Success", "Health log saved successfully!");
-			} else if (result.error && !String(result.error).startsWith("Missing required")) {
-				const errorMessage = String(result.error);
-				if (errorMessage.startsWith("Failed to ")) {
-					Alert.alert("Error", errorMessage);
-				} else {
-					Alert.alert("Error", `Failed to save health log: ${errorMessage}`);
-				}
+		const result = await saveHealthLog();
+		if (result.success) {
+			router.replace("/(tabs)");
+			Alert.alert("Success", "Health log saved successfully!");
+		} else if (result.error && !String(result.error).startsWith("Missing required")) {
+			const errorMessage = String(result.error);
+			if (errorMessage.startsWith("Failed to ")) {
+				Alert.alert("Error", errorMessage);
+			} else {
+				Alert.alert("Error", `Failed to save health log: ${errorMessage}`);
 			}
-		} finally {
-			setIsSaving(false);
 		}
+		setIsSaving(false);
 	};
 
 	// Update date in state when changed

--- a/app/(trackers)/milestone.tsx
+++ b/app/(trackers)/milestone.tsx
@@ -258,17 +258,14 @@ export default function Milestone() {
 		
 		if (name && milestoneDate) {
 			setIsSaving(true);
-			try {
-				const result = await saveMilestoneLog();
-				if (result.success) {
-					router.replace("/(tabs)");
-					Alert.alert("Milestone log saved successfully!");
-				} else {
-					Alert.alert(`Failed to save milestone log: ${result.error}`);
-				}
-			} finally {
-				setIsSaving(false);
+			const result = await saveMilestoneLog();
+			if (result.success) {
+				router.replace("/(tabs)");
+				Alert.alert("Milestone log saved successfully!");
+			} else {
+				Alert.alert(`Failed to save milestone log: ${result.error}`);
 			}
+			setIsSaving(false);
 		} else {
 			const missingFields = [];
 			if (!name) missingFields.push("name");

--- a/app/(trackers)/nursing.tsx
+++ b/app/(trackers)/nursing.tsx
@@ -149,17 +149,14 @@ export default function Nursing() {
 			rightAmount.trim() !== ""
 		) {
 			setIsSaving(true);
-			try {
-				const result = await saveNursingLog();
-				if (result.success) {
-					router.replace("/(tabs)");
-					Alert.alert("Nursing log saved successfully!");
-				} else {
-					Alert.alert(`Failed to save nursing log: ${result.error}`);
-				}
-			} finally {
-				setIsSaving(false);
+			const result = await saveNursingLog();
+			if (result.success) {
+				router.replace("/(tabs)");
+				Alert.alert("Nursing log saved successfully!");
+			} else {
+				Alert.alert(`Failed to save nursing log: ${result.error}`);
 			}
+			setIsSaving(false);
 		} else {
 			const missingFields = [];
 			if (leftDuration === "00:00:00" || rightDuration === "00:00:00")

--- a/app/(trackers)/sleep.tsx
+++ b/app/(trackers)/sleep.tsx
@@ -154,17 +154,14 @@ export default function Sleep() {
 
 		if (stopwatchTime && stopwatchTime !== "00:00:00") {
 			setIsSaving(true);
-			try {
-				const result = await saveSleepLog(stopwatchTime, null, null, note);
-				if (result.success) {
-					router.replace("/(tabs)");
-					Alert.alert("Sleep log saved successfully!");
-				} else {
-					Alert.alert(`Failed to save sleep log: ${result.error}`);
-				}
-			} finally {
-				setIsSaving(false);
+			const result = await saveSleepLog(stopwatchTime, null, null, note);
+			if (result.success) {
+				router.replace("/(tabs)");
+				Alert.alert("Sleep log saved successfully!");
+			} else {
+				Alert.alert(`Failed to save sleep log: ${result.error}`);
 			}
+			setIsSaving(false);
 		} else if (startTime && endTime) {
 			if (endTime.getTime() <= startTime.getTime()) {
 				Alert.alert(


### PR DESCRIPTION
# What
- Adds an `isSaving` variable to set the state of the "Add to Log" button
- When `isSaving` is true, the `disabled` prop is activated for this button, denying any repeated presses to the add log button
- Prevents repeated/duplicate logs when saving

# Look
![Simulator Screen Recording - iPhone 16e - 2026-03-02 at 17 18 25](https://github.com/user-attachments/assets/e868ebd0-579c-4b86-b5df-8cc9c96cfedf)

# How to Test
- Build and log into the app
- Open a log tracker of your choice (e.g., Diaper, Sleep, etc.)
- Tap the "add to log" button to ensure that empty fields are still checked for errors
- Fill out all necessary fields
- Spam the "add to log" button and submit
- Check the log in its respective tracker to ensure only *one* log was saved
- Repeat these steps for all other trackers in the app

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-154)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
