### PR TITLE
KAN-160: Fix Unexpected Behavior in Log Pages

### DIFF
--- a/app/(logs)/diaper-logs.tsx
+++ b/app/(logs)/diaper-logs.tsx
@@ -44,6 +44,7 @@ const DiaperLogsView: React.FC = () => {
 	const [activeChildName, setActiveChildName] = useState<string | null>(null);
 	const [editingLog, setEditingLog] = useState<DiaperLog | null>(null);
 	const [editModalVisible, setEditModalVisible] = useState(false);
+	const [deleteAlertVisible, setDeleteAlertVisible] = useState(false);
 	const { isGuest } = useAuth();
 
 	const safeDecrypt = async (value: string | null): Promise<string> => {
@@ -137,8 +138,9 @@ const DiaperLogsView: React.FC = () => {
 	}, [fetchDiaperLogs]);
 
 	const handleDelete = async (id: string) => {
+		setDeleteAlertVisible(true);
 		Alert.alert("Delete Entry", "Are you sure you want to delete this log?", [
-			{ text: "Cancel", style: "cancel" },
+			{ text: "Cancel", style: "cancel", onPress: () => { setDeleteAlertVisible(false); } },
 			{
 				text: "Delete",
 				style: "destructive",
@@ -162,6 +164,7 @@ const DiaperLogsView: React.FC = () => {
                         }
                         setDiaperLogs((prev) => prev.filter((log) => log.id !== id));
                     }
+					setDeleteAlertVisible(false);
 				},
 			},
 		]);
@@ -234,9 +237,10 @@ const DiaperLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-blue-100"
 					onPress={() => {
-						setEditingLog(item);
 						setEditModalVisible(true);
+						setEditingLog(item);
 					}}
+					disabled={deleteAlertVisible}
 					testID={`diaper-logs-edit-button-${item.id}`}
 				>
 					<Text className="text-blue-700">✏️ Edit</Text>
@@ -244,6 +248,7 @@ const DiaperLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-red-100"
 					onPress={() => handleDelete(item.id)}
+					disabled={editModalVisible}
 					testID={`diaper-logs-delete-button-${item.id}`}
 				>
 					<Text className="text-red-700">🗑️ Delete</Text>

--- a/app/(logs)/feeding-logs.tsx
+++ b/app/(logs)/feeding-logs.tsx
@@ -44,6 +44,7 @@ const FeedingLogsView: React.FC = () => {
 	const [error, setError] = useState<string | null>(null);
 	const [editingLog, setEditingLog] = useState<FeedingLog | null>(null);
 	const [editModalVisible, setEditModalVisible] = useState(false);
+	const [deleteAlertVisible, setDeleteAlertVisible] = useState(false);
 	const { isGuest } = useAuth();
 	const [activeChildName, setActiveChildName] = useState<string | null>(null);
 
@@ -144,8 +145,9 @@ const FeedingLogsView: React.FC = () => {
 	}, [fetchFeedingLogs]);
 
 	const handleDelete = async (id: string) => {
+		setDeleteAlertVisible(true);
 		Alert.alert("Delete Entry", "Are you sure you want to delete this log?", [
-			{ text: "Cancel", style: "cancel" },
+			{ text: "Cancel", style: "cancel", onPress: () => { setDeleteAlertVisible(false); } },
 			{
 				text: "Delete",
 				style: "destructive",
@@ -171,6 +173,7 @@ const FeedingLogsView: React.FC = () => {
 
 						setFeedingLogs((prev) => prev.filter((log) => log.id !== id));
 					}
+					setDeleteAlertVisible(false);
 				},
 			},
 		]);
@@ -251,9 +254,10 @@ const FeedingLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-blue-100"
 					onPress={() => {
-						setEditingLog(item);
 						setEditModalVisible(true);
+						setEditingLog(item);
 					}}
+					disabled={deleteAlertVisible}
 					testID={`feeding-logs-edit-button-${item.id}`}
 				>
 					<Text className="text-blue-700">✏️ Edit</Text>
@@ -261,6 +265,7 @@ const FeedingLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-red-100"
 					onPress={() => handleDelete(item.id)}
+					disabled={editModalVisible}
 					testID={`feeding-logs-delete-button-${item.id}`}
 				>
 					<Text className="text-red-700">🗑️ Delete</Text>

--- a/app/(logs)/health-logs.tsx
+++ b/app/(logs)/health-logs.tsx
@@ -54,6 +54,7 @@ const HealthLogsView: React.FC = () => {
 	const [error, setError] = useState<string | null>(null);
 	const [editingLog, setEditingLog] = useState<HealthLog | null>(null);
 	const [editModalVisible, setEditModalVisible] = useState(false);
+	const [deleteAlertVisible, setDeleteAlertVisible] = useState(false);
 	const { isGuest } = useAuth();
 	const [activeChildName, setActiveChildName] = useState<string | null>(null);
 
@@ -230,8 +231,9 @@ const HealthLogsView: React.FC = () => {
 	};
 
 	const handleDelete = async (id: string) => {
+		setDeleteAlertVisible(true);
 		Alert.alert("Delete Entry", "Are you sure you want to delete this log?", [
-			{ text: "Cancel", style: "cancel" },
+			{ text: "Cancel", style: "cancel", onPress: () => { setDeleteAlertVisible(false); } },
 			{
 				text: "Delete",
 				style: "destructive",
@@ -254,6 +256,7 @@ const HealthLogsView: React.FC = () => {
                         }
                         setLogs((prev) => prev.filter((log) => log.id !== id));
                     }
+					setDeleteAlertVisible(false);
 				},
 			},
 		]);
@@ -287,9 +290,10 @@ const HealthLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-blue-100"
 					onPress={() => {
-						setEditingLog(item);
 						setEditModalVisible(true);
+						setEditingLog(item);
 					}}
+					disabled={deleteAlertVisible}
 					testID={`health-logs-edit-button-${item.id}`}
 				>
 					<Text className="text-blue-700">✏️ Edit</Text>
@@ -297,6 +301,7 @@ const HealthLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-red-100"
 					onPress={() => handleDelete(item.id)}
+					disabled={editModalVisible}
 					testID={`health-logs-delete-button-${item.id}`}
 				>
 					<Text className="text-red-700">🗑️ Delete</Text>

--- a/app/(logs)/milestone-logs.tsx
+++ b/app/(logs)/milestone-logs.tsx
@@ -63,6 +63,7 @@ const MilestoneLogsView: React.FC = () => {
 	const [activeChildName, setActiveChildName] = useState<string | null>(null);
 	const [editingLog, setEditingLog] = useState<MilestoneLog | null>(null);
 	const [editModalVisible, setEditModalVisible] = useState(false);
+	const [deleteAlertVisible, setDeleteAlertVisible] = useState(false);
 	const [photoSignedUrls, setPhotoSignedUrls] = useState<
 		Record<string, string>
 	>({});
@@ -267,11 +268,12 @@ const MilestoneLogsView: React.FC = () => {
 	};
 
 	const handleDelete = async (id: string) => {
+		setDeleteAlertVisible(true);
 		Alert.alert(
 			"Delete Entry",
 			"Are you sure you want to delete this log?",
 			[
-				{ text: "Cancel", style: "cancel" },
+				{ text: "Cancel", style: "cancel", onPress: () => { setDeleteAlertVisible(false); } },
 				{
 					text: "Delete",
 					style: "destructive",
@@ -295,6 +297,7 @@ const MilestoneLogsView: React.FC = () => {
                             }
                             setMilestoneLogs((prev) => prev.filter((log) => log.id !== id));
                         }
+						setDeleteAlertVisible(false);
 					},
 				},
 			],
@@ -343,7 +346,11 @@ const MilestoneLogsView: React.FC = () => {
 				<View className="flex-row justify-end gap-3 mt-4">
 					<Pressable
 						className="px-3 py-2 rounded-full bg-blue-100"
-						onPress={() => openEditModal(item)}
+						onPress={() => {
+							setEditModalVisible(true); 
+							openEditModal(item);
+						}}
+						disabled={deleteAlertVisible}
 						testID={`milestone-logs-edit-button-${item.id}`}
 					>
 						<Text className="text-blue-700">✏️ Edit</Text>
@@ -352,6 +359,7 @@ const MilestoneLogsView: React.FC = () => {
 					<Pressable
 						className="px-3 py-2 rounded-full bg-red-100"
 						onPress={() => handleDelete(item.id)}
+						disabled={editModalVisible}
 						testID={`milestone-logs-delete-button-${item.id}`}
 					>
 						<Text className="text-red-700">🗑️ Delete</Text>

--- a/app/(logs)/nursing-logs.tsx
+++ b/app/(logs)/nursing-logs.tsx
@@ -45,6 +45,7 @@ const NursingLogsView: React.FC = () => {
 	const [error, setError] = useState<string | null>(null);
 	const [editingLog, setEditingLog] = useState<NursingLog | null>(null);
 	const [editModalVisible, setEditModalVisible] = useState(false);
+	const [deleteAlertVisible, setDeleteAlertVisible] = useState(false);
 	const { isGuest } = useAuth();
 	const [activeChildName, setActiveChildName] = useState<string | null>(null);
 
@@ -187,8 +188,9 @@ const NursingLogsView: React.FC = () => {
 	};
 
 	const handleDelete = async (id: string) => {
+		setDeleteAlertVisible(true);
 		Alert.alert("Delete Entry", "Are you sure you want to delete this log?", [
-			{ text: "Cancel", style: "cancel" },
+			{ text: "Cancel", style: "cancel", onPress: () => { setDeleteAlertVisible(false); } },
 			{
 				text: "Delete",
 				style: "destructive",
@@ -212,6 +214,7 @@ const NursingLogsView: React.FC = () => {
                         }
                         setNursingLogs((prev) => prev.filter((log) => log.id !== id));
                     }
+					setDeleteAlertVisible(false);
 				},
 			},
 		]);
@@ -252,9 +255,10 @@ const NursingLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-blue-100"
 					onPress={() => {
-						setEditingLog(item);
 						setEditModalVisible(true);
+						setEditingLog(item);
 					}}
+					disabled={deleteAlertVisible}
 					testID={`nursing-logs-edit-button-${item.id}`}
 				>
 					<Text className="text-blue-700">✏️ Edit</Text>
@@ -262,6 +266,7 @@ const NursingLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-red-100"
 					onPress={() => handleDelete(item.id)}
+					disabled={editModalVisible}
 					testID={`nursing-logs-delete-button-${item.id}`}
 				>
 					<Text className="text-red-700">🗑️ Delete</Text>

--- a/app/(logs)/sleep-logs.tsx
+++ b/app/(logs)/sleep-logs.tsx
@@ -43,6 +43,7 @@ const SleepLogsView: React.FC = () => {
 	const [error, setError] = useState<string | null>(null);
 	const [editingLog, setEditingLog] = useState<SleepLog | null>(null);
 	const [editModalVisible, setEditModalVisible] = useState(false);
+	const [deleteAlertVisible, setDeleteAlertVisible] = useState(false);
 	const [activeChildName, setActiveChildName] = useState<string | null>(null);
 	const { isGuest } = useAuth();
 
@@ -133,8 +134,9 @@ const SleepLogsView: React.FC = () => {
 	}, [fetchSleepLogs]);
 
 	const handleDelete = async (id: string) => {
+		setDeleteAlertVisible(true);
 		Alert.alert("Delete Entry", "Are you sure you want to delete this log?", [
-			{ text: "Cancel", style: "cancel" },
+			{ text: "Cancel", style: "cancel", onPress: () => { setDeleteAlertVisible(false); } },
 			{
 				text: "Delete",
 				style: "destructive",
@@ -158,6 +160,7 @@ const SleepLogsView: React.FC = () => {
 						}
 						setSleepLogs((prev) => prev.filter((log) => log.id !== id));
 					}
+					setDeleteAlertVisible(false);
 				},
 			},
 		]);
@@ -233,9 +236,10 @@ const SleepLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-blue-100"
 					onPress={() => {
-						setEditingLog(item);
 						setEditModalVisible(true);
+						setEditingLog(item);
 					}}
+					disabled={deleteAlertVisible}
 					testID={`sleep-logs-edit-button-${item.id}`}
 				>
 					<Text className="text-blue-700">✏️ Edit</Text>
@@ -243,6 +247,7 @@ const SleepLogsView: React.FC = () => {
 				<Pressable
 					className="px-3 py-2 rounded-full bg-red-100"
 					onPress={() => handleDelete(item.id)}
+					disabled={editModalVisible}
 					testID={`sleep-logs-delete-button-${item.id}`}
 				>
 					<Text className="text-red-700">🗑️ Delete</Text>


### PR DESCRIPTION
# What
- Adds `useState` variables, `deleteAlertVisible` and `setDeleteAlertVisible`, in all log viewer pages
- Sets `deleteAlertVisible(true)` when `handleDelete()` is called in all log viewer pages
- Enables the `disabled` prop in the edit button when `deleteAlertVisible` is true
- Enables the `disabled` prop in the delete button when `editModalVisible` is true

# Look
[kan-160-fix.webm](https://github.com/user-attachments/assets/cd461481-6f26-474f-9ce8-dac38310e267)

# How to Test
- Build the app on Android and log in
  - (NOTE: This defect seems to only apply to Android. I was not able to recreate it on iOS)
- Log in to the app
- Create a log of any type and save it
- Go and view the log in the trends tab
- Then, quickly tap the delete tab and then the edit tab within less than a second of each other (i.e., try to press both at the exact time as fast as possible)
- Repeat vice versa for the edit tab, then press the delete tab
- Verify that the behavior is now fixed and only one modal/alert is shown at a time

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-160)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
