### PR TITLE
KAN-164: Remove Units when Saving Growth Logs

### DIFF
--- a/app/(logs)/health-logs.tsx
+++ b/app/(logs)/health-logs.tsx
@@ -268,9 +268,9 @@ const HealthLogsView: React.FC = () => {
 			<Text className="text-base">
 				{format(new Date(item.date), "MMM dd, yyyy")}
 			</Text>
-			{item.growth_length && <Text>Length: {item.growth_length} cm</Text>}
-			{item.growth_weight && <Text>Weight: {item.growth_weight} kg</Text>}
-			{item.growth_head && <Text>Head: {item.growth_head} cm</Text>}
+			{item.growth_length && <Text>Length: {item.growth_length}</Text>}
+			{item.growth_weight && <Text>Weight: {item.growth_weight}</Text>}
+			{item.growth_head && <Text>Head: {item.growth_head}</Text>}
 			{item.activity_type && <Text>Activity: {item.activity_type}</Text>}
 			{item.activity_duration && (
 				<Text>Duration: {item.activity_duration}</Text>


### PR DESCRIPTION
# What
- Removes "kg" and "cm" strings from the measurements saved in Growth Health Logs

# Look
![Simulator Screen Recording - iPhone 16e - 2026-03-11 at 17 29 12](https://github.com/user-attachments/assets/61e5ce66-71b6-43d7-9f23-77647ba483c2)

# How to Test
- Build and log in to the app
- Go to Health Logs
- Select the Growth category
- Enter any valid inputs for the length, weight, and head measurements
- Add the log, then go view it
- Validate that "kg" and "cm" are no longer affixed to any of the measurements

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-164)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
