### PR TITLE
Added edit date/time options

### DIFF
--- a/app/(logs)/diaper-logs.tsx
+++ b/app/(logs)/diaper-logs.tsx
@@ -28,7 +28,7 @@ interface DiaperLog {
 	child_id: string;
 	consistency: string;
 	amount: string;
-	change_time: string;
+	change_time: Date;
 	note: string | null;
 }
 
@@ -78,6 +78,7 @@ const DiaperLogsView: React.FC = () => {
 						...entry,
 						consistency: await safeDecrypt(entry.consistency),
 						amount: await safeDecrypt(entry.amount),
+						change_time: new Date(entry.change_time),
 						note: entry.note ? await safeDecrypt(entry.note) : "",
 					})),
 				);
@@ -114,6 +115,7 @@ const DiaperLogsView: React.FC = () => {
                         ...entry,
                         consistency: await safeDecrypt(entry.consistency),
                         amount: await safeDecrypt(entry.amount),
+						change_time: new Date(entry.change_time),
                         note: entry.note ? await safeDecrypt(entry.note) : "",
                     })),
                 );
@@ -171,7 +173,7 @@ const DiaperLogsView: React.FC = () => {
 		if (!editingLog) return;
 
 		try {
-			const { id, consistency, amount, note } = editingLog;
+			const { id, consistency, amount, change_time, note } = editingLog;
 
 			const encryptedConsistency = await encryptData(consistency);
 			const encryptedAmount = await encryptData(amount);
@@ -181,6 +183,7 @@ const DiaperLogsView: React.FC = () => {
 				const success = await updateRow("diaper_logs", id, {
 					consistency: encryptedConsistency,
 					amount: encryptedAmount,
+					change_time: change_time.toISOString(),
 					note: encryptedNote,
 				});
 				if (!success) {
@@ -197,6 +200,7 @@ const DiaperLogsView: React.FC = () => {
                     .update({
                         consistency: encryptedConsistency,
                         amount: encryptedAmount,
+						change_time: change_time.toISOString(),
                         note: encryptedNote,
                     })
                     .eq("id", id);
@@ -218,10 +222,10 @@ const DiaperLogsView: React.FC = () => {
 	const renderDiaperLogItem = ({ item }: { item: DiaperLog }) => (
 		<View className="bg-white rounded-xl p-4 mb-4 shadow">
 			<Text className="text-lg font-bold mb-2">
-				{format(new Date(item.change_time), "MMM dd, yyyy")}
+				{format(item.change_time, "MMM dd, yyyy")}
 			</Text>
 			<Text className="text-base mb-1">
-				{format(new Date(item.change_time), "h:mm a")}
+				{format(item.change_time, "h:mm a")}
 			</Text>
 			<Text className="text-base mb-1">Consistency: {item.consistency}</Text>
 			<Text className="text-base mb-1">Size: {item.amount}</Text>
@@ -295,6 +299,11 @@ const DiaperLogsView: React.FC = () => {
 						type: "category",
 						categories: ["SM", "MD", "LG"],
 						value: editingLog?.amount,
+					},
+					change_time: {
+						title: "Change Time",
+						type: "time",
+						value: editingLog?.change_time,
 					},
 					note:  {
 						title: "Note",

--- a/app/(logs)/feeding-logs.tsx
+++ b/app/(logs)/feeding-logs.tsx
@@ -29,7 +29,7 @@ interface FeedingLog {
 	category: string;
 	item_name: string;
 	amount: string;
-	feeding_time: string;
+	feeding_time: Date;
 	note: string | null;
 }
 
@@ -84,6 +84,7 @@ const FeedingLogsView: React.FC = () => {
 						category: await safeDecrypt(entry.category),
 						item_name: await safeDecrypt(entry.item_name),
 						amount: await safeDecrypt(entry.amount),
+						feeding_time: new Date(entry.feeding_time),
 						note: entry.note ? await safeDecrypt(entry.note) : "",
 					})),
 				);
@@ -121,6 +122,7 @@ const FeedingLogsView: React.FC = () => {
 						category: await safeDecrypt(entry.category),
 						item_name: await safeDecrypt(entry.item_name),
 						amount: await safeDecrypt(entry.amount),
+						feeding_time: new Date(entry.feeding_time),
 						note: entry.note ? await safeDecrypt(entry.note) : "",
 					})),
 				);
@@ -180,7 +182,7 @@ const FeedingLogsView: React.FC = () => {
 		if (!editingLog) return;
 
 		try {
-			const { id, category, item_name, amount, note } = editingLog;
+			const { id, category, item_name, amount, feeding_time, note } = editingLog;
 
 			const encryptedCategory = await encryptData(category);
 			const encryptedItemName = await encryptData(item_name);
@@ -192,6 +194,7 @@ const FeedingLogsView: React.FC = () => {
 					category: encryptedCategory,
 					item_name: encryptedItemName,
 					amount: encryptedAmount,
+					feeding_time: feeding_time.toISOString(),
 					note: encryptedNote,
 				});
 				if (!success) {
@@ -209,6 +212,7 @@ const FeedingLogsView: React.FC = () => {
 						category: encryptedCategory,
 						item_name: encryptedItemName,
 						amount: encryptedAmount,
+						feeding_time: feeding_time.toISOString(),
 						note: encryptedNote,
 					})
 					.eq("id", id);
@@ -234,10 +238,10 @@ const FeedingLogsView: React.FC = () => {
 	const renderFeedingLogItem = ({ item }: { item: FeedingLog }) => (
 		<View className="bg-white rounded-xl p-4 mb-4 shadow">
 			<Text className="text-lg font-bold mb-2">
-				{format(new Date(item.feeding_time), "MMM dd, yyyy")}
+				{format(item.feeding_time, "MMM dd, yyyy")}
 			</Text>
 			<Text className="text-base mb-1">
-				{format(new Date(item.feeding_time), "h:mm a")}
+				{format(item.feeding_time, "h:mm a")}
 			</Text>
 			<Text className="text-base mb-1">Category: {item.category}</Text>
 			<Text className="text-base mb-1">Item: {item.item_name}</Text>
@@ -316,6 +320,11 @@ const FeedingLogsView: React.FC = () => {
 						title: "Amount",
 						type: "text",
 						value: editingLog?.amount,
+					},
+					feeding_time: {
+						title: "Meal Time",
+						type: "time",
+						value: editingLog?.feeding_time,
 					},
 					note:  {
 						title: "Note",

--- a/app/(logs)/health-logs.tsx
+++ b/app/(logs)/health-logs.tsx
@@ -27,7 +27,7 @@ interface HealthLog {
 	id: string;
 	child_id: string;
 	category: string;
-	date: string;
+	date: Date;
 	growth_length: string | null;
 	growth_weight: string | null;
 	growth_head: string | null;
@@ -97,6 +97,7 @@ const HealthLogsView: React.FC = () => {
 						vaccine_location: await safeDecrypt(entry.vaccine_location),
 						other_name: await safeDecrypt(entry.other_name),
 						other_description: await safeDecrypt(entry.other_description),
+						date: new Date(entry.date),
 						note: await safeDecrypt(entry.note),
 					})),
 				);
@@ -142,6 +143,7 @@ const HealthLogsView: React.FC = () => {
                         vaccine_location: await safeDecrypt(entry.vaccine_location),
                         other_name: await safeDecrypt(entry.other_name),
                         other_description: await safeDecrypt(entry.other_description),
+						date: new Date(entry.date),
                         note: await safeDecrypt(entry.note),
                     })),
                 );
@@ -197,6 +199,7 @@ const HealthLogsView: React.FC = () => {
 				other_description: editingLog.other_description
 					? await encryptData(editingLog.other_description)
 					: null,
+				date: editingLog.date.toISOString(),
 				note: editingLog.note ? await encryptData(editingLog.note) : null,
 			};
 
@@ -263,7 +266,7 @@ const HealthLogsView: React.FC = () => {
 		<View className="bg-white rounded-xl p-4 mb-4 shadow">
 			<Text className="text-lg font-bold mb-1">{item.category}</Text>
 			<Text className="text-base">
-				{format(new Date(item.date), "MMM dd, yyyy")}
+				{format(item.date, "MMM dd, yyyy")}
 			</Text>
 			{item.growth_length && <Text>Length: {item.growth_length}</Text>}
 			{item.growth_weight && <Text>Weight: {item.growth_weight}</Text>}
@@ -403,7 +406,12 @@ const HealthLogsView: React.FC = () => {
 						value: editingLog?.other_description,
 					}},
 
-					// Note input, displayed for all categories
+					// Date & note input displayed for all categories
+					date:  {
+						title: "Date",
+						type: "date",
+						value: editingLog?.date,
+					},
 					note:  {
 						title: "Note",
 						type: "text",

--- a/test/app/(logs)/diaper-logs.test.tsx
+++ b/test/app/(logs)/diaper-logs.test.tsx
@@ -520,6 +520,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
         const editedConsistency = `edited consistency ${log.id}`;
         const editedAmount = `edited amount ${log.id}`;
         const editedNote = `edited note ${log.id}`;
+        const editedTime = new Date((new Date(log.change_time)).getTime() - 74*60*1000);
 
         // clear .mock.calls array each loop
         idMock.mockClear();
@@ -539,6 +540,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
                 ...prev,
                 consistency: editedConsistency,
                 amount: editedAmount,
+                change_time: editedTime,
                 note: editedNote,
             }))
         );
@@ -552,6 +554,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
             .toEqual({  // loose comparison for objects
                 consistency: await encryptData(editedConsistency),
                 amount: await encryptData(editedAmount),
+                change_time: editedTime.toISOString(),
                 note: await encryptData(editedNote),
             });
         // Ensure mock was called with correct id

--- a/test/app/(logs)/feeding-logs.test.tsx
+++ b/test/app/(logs)/feeding-logs.test.tsx
@@ -527,6 +527,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
         const editedItem = `edited item ${log.id}`;
         const editedAmount = `edited amount ${log.id}`;
         const editedNote = `edited note ${log.id}`;
+        const editedTime = new Date((new Date(log.feeding_time)).getTime() - 74*60*1000);
 
         // clear .mock.calls array each loop
         idMock.mockClear();
@@ -547,6 +548,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
                 category: editedCategory,
                 item_name: editedItem,
                 amount: editedAmount,
+                feeding_time: editedTime,
                 note: editedNote,
             }))
         );
@@ -561,6 +563,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
                 category: await encryptData(editedCategory),
                 item_name: await encryptData(editedItem),
                 amount: await encryptData(editedAmount),
+                feeding_time: editedTime.toISOString(),
                 note: await encryptData(editedNote),
             });
         // Ensure mock was called with correct id

--- a/test/app/(logs)/health-logs.test.tsx
+++ b/test/app/(logs)/health-logs.test.tsx
@@ -611,6 +611,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
 
         const editFields = [
             log.note ? "note" : null,
+            "date",
             // growth category values
             log.test_category === "growth" ? "growth_head" : null,
             log.test_category === "growth" ? "growth_length" : null,
@@ -628,6 +629,7 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
             log.test_category === "other" ? "other_name" : null,
             log.test_category === "other" ? "other_description" : null,
         ].filter(value => value !== null);  // remove null values
+        const editedDate = new Date((new Date(log.date)).getTime() + 5*24*60*60*1000);
 
         // clear .mock.calls array each loop
         idMock.mockClear();
@@ -644,7 +646,10 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
         // clear set new field values from <EditLogPopup/>
         const editedFields = Object.fromEntries(
             editFields.map(field => (
-                [field, `edited ${field} ${log.id}`]
+                field === "date" ?
+                    [field, editedDate]
+                :
+                    [field, `edited ${field} ${log.id}`]
             ))
         );
         await act(async () =>
@@ -662,7 +667,11 @@ async function updateRemoteLogs(dataMock: jest.Mock, dataArgI: number, idMock: j
         const submitedData = dataMock.mock.calls[0][dataArgI];
         for (const [field, submittedValue] of Object.entries(submitedData)) {
             if (editFields.includes(field)) {
-                expect(submittedValue).toBe(await encryptData(`edited ${field} ${log.id}`));
+                if (field === "date") {
+                    expect(submittedValue).toBe(editedDate.toISOString());
+                } else {
+                    expect(submittedValue).toBe(await encryptData(`edited ${field} ${log.id}`));
+                }
             } else {
                 expect(submittedValue).toBe(null);
             }


### PR DESCRIPTION
# What
- Added time/date entries to edit log pop-ups for diaper, feeding, and health logs
- Changed stored log date/times from string to Date objects for those log pages
- Updated unit tests

# Look
feeding log edit time option:
<img width="272" height="638" alt="image" src="https://github.com/user-attachments/assets/d62d267c-9690-4820-9c4e-577fb6e7cf08" />

diaper log edit time option:
<img width="272" height="638" alt="image" src="https://github.com/user-attachments/assets/585b98ce-15fe-40ce-a486-b87c5d57ff96" />

health log edit date option:
<img width="272" height="638" alt="image" src="https://github.com/user-attachments/assets/5a6ae54f-603f-4e4d-a942-f3375c8c1336" />

# How to Test
- checkout this branch
*For each of diaper/feeding/health logs:*
- find a log in the log page, and open the edit pop-up
- make sure there is an option to edit the date (health) or time (diaper/feeding)
- changing this time should visually update the pop-up, and update the log page after pressing save
- ensure that changing the date/time changes the visual ordering of logs displayed if updating the date/time changed the chronological ordering

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-166)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
