### PR TITLE
KAN-230: Make Note Field Multiline When Editing Logs

### DIFF
--- a/components/edit-log-popup.tsx
+++ b/components/edit-log-popup.tsx
@@ -144,6 +144,7 @@ export default function EditLogPopup({
                 )
             }
             testID={fieldInfo.testID}
+            multiline={fieldInfo.title === "Note"}
         />
     );
     


### PR DESCRIPTION
# What
- Sets the edit log field for notes to be multiline if (and only if) the edit log field is of type "Note"

# Look
![Simulator Screen Recording - iPhone 16e - 2026-04-08 at 23 34 26](https://github.com/user-attachments/assets/a891eaaa-de10-495d-baee-d764fde13dde)

# How to Test
- Check out this branch and log into the app
- Create a test log of any type and add a note
- View the log in your respective category and press the edit button
- Type a long note in the edit field and verify that multiple lines appear if the note runs long

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-230)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
