### PR TITLE
KAN-232: Use "Amount" instead of "Size" for Diaper Logs

### DIFF
--- a/app/(logs)/diaper-logs.tsx
+++ b/app/(logs)/diaper-logs.tsx
@@ -228,7 +228,7 @@ const DiaperLogsView: React.FC = () => {
 				{ type: "title", value: format(item.change_time, "MMM dd, yyyy") },
 				{ type: "text", value: format(item.change_time, "h:mm a") },
 				{ type: "item", label: "Consistency", value: item.consistency },
-				{ type: "item", label: "Size", value: item.amount },
+				{ type: "item", label: "Amount", value: item.amount },
 				{ type: "note", value: item.note},
 			]}
 		/>


### PR DESCRIPTION
# What
- Fixes the consistency of diaper log labels by using "Amount" in all references to Diaper logs
  - Previously, "size" and "amount" were used interchangeably when creating/viewing/editing these logs

# Look
<img width="293" height="633" alt="Simulator Screenshot - iPhone 16e - 2026-04-09 at 11 18 10" src="https://github.com/user-attachments/assets/9ee1f671-89fc-40d8-a49e-aa89fe41633e" />
<img width="293" height="633" alt="Simulator Screenshot - iPhone 16e - 2026-04-09 at 11 18 15" src="https://github.com/user-attachments/assets/69e900a3-5527-4171-89d4-7223cefd6c95" />
<img width="293" height="633" alt="Simulator Screenshot - iPhone 16e - 2026-04-09 at 11 18 18" src="https://github.com/user-attachments/assets/c0b952f6-1883-4c35-91a9-77f8dc3874a7" />

# How to Test
- n/a

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-232)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
