### PR TITLE
KAN-233: Fix First/Last Name Input Field Styling

### DIFF
--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -117,11 +117,11 @@ const SignUpScreen: React.FC = () => {
                     behavior={'padding'}
                 >
                     <View className='flex-row gap-4'>
-                        <View className='grow'>
+                        <View className='flex-1'>
                             <Text className='text font-bold'>First Name</Text>
                             <TextInput
                                 className='text-input'
-                                placeholder='Enter your name'
+                                placeholder='Enter your first name'
                                 value={firstName}
                                 onChangeText={setFirstName}
                                 autoCapitalize='none'
@@ -129,7 +129,7 @@ const SignUpScreen: React.FC = () => {
                                 testID="sign-up-first-name"
                             />
                         </View>
-                        <View className='grow'>
+                        <View className='flex-1'>
                             <Text className='text font-bold'>Last Name</Text>
                             <TextInput
                                 className='text-input'


### PR DESCRIPTION
# What
- Sets `<View>` components in `signup.tsx` to `flex-1` for first/last name input fields, preventing the size of the inputs from changing depending on what the user types

# Look
![Simulator Screen Recording - iPhone 16e - 2026-04-09 at 11 53 03](https://github.com/user-attachments/assets/0f909c30-72ed-4fce-8845-d582e8614d61)

# How to Test
- Check out this branch and build the app
- Go to the sign-up page, and type in a bunch of random characters for first/last names
- Verify that the fields no longer change size and cut each other off

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-233)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
