### PR TITLE
Kan 235/unexpected navigation

### DIFF
--- a/app/(trackers)/diaper.tsx
+++ b/app/(trackers)/diaper.tsx
@@ -88,7 +88,7 @@ export default function Diaper() {
 		}, isGuest, "diaper");
 
 		if (result.success) {
-			router.replace("/(tabs)");
+			router.dismissTo("/(tabs)");
 			Alert.alert("Diaper log saved successfully!");
 		} else {
 			Alert.alert(`Failed to save diaper log: ${result.error}`);

--- a/app/(trackers)/feeding.tsx
+++ b/app/(trackers)/feeding.tsx
@@ -95,7 +95,7 @@ export default function Feeding() {
 		}, isGuest, "feeding");
 
 		if (result.success) {
-			router.replace("/(tabs)");
+			router.dismissTo("/(tabs)");
 			Alert.alert("Feeding log saved successfully!");
 		} else {
 			Alert.alert(`Failed to save feeding log: ${result.error}`);

--- a/app/(trackers)/health.tsx
+++ b/app/(trackers)/health.tsx
@@ -158,7 +158,7 @@ export default function Health() {
 		}, isGuest, "health");
 
 		if (result.success) {
-			router.replace("/(tabs)");
+			router.dismissTo("/(tabs)");
 			Alert.alert("Success", "Health log saved successfully!");
 		} else if (result.error) {
 			const errorMessage = String(result.error);

--- a/app/(trackers)/milestone.tsx
+++ b/app/(trackers)/milestone.tsx
@@ -165,7 +165,7 @@ export default function Milestone() {
 		}, isGuest, "milestone", setUploadingPhoto);
 
 		if (result.success) {
-			router.replace("/(tabs)");
+			router.dismissTo("/(tabs)");
 			Alert.alert("Milestone log saved successfully!");
 		} else {
 			Alert.alert(`Failed to save milestone log: ${result.error}`);

--- a/app/(trackers)/nursing.tsx
+++ b/app/(trackers)/nursing.tsx
@@ -96,7 +96,7 @@ export default function Nursing() {
 		}, isGuest, "nursing");
 
 		if (result.success) {
-			router.replace("/(tabs)");
+			router.dismissTo("/(tabs)");
 			Alert.alert("Nursing log saved successfully!");
 		} else {
 			Alert.alert(`Failed to save nursing log: ${result.error}`);

--- a/app/(trackers)/sleep.tsx
+++ b/app/(trackers)/sleep.tsx
@@ -123,7 +123,7 @@ export default function Sleep() {
 		}, isGuest, "sleep");
 
 		if (result.success) {
-			router.replace("/(tabs)");
+			router.dismissTo("/(tabs)");
 			Alert.alert("Sleep log saved successfully!");
 		} else {
 			Alert.alert(`Failed to save sleep log: ${result.error}`);

--- a/test/app/(trackers)/diaper.test.tsx
+++ b/test/app/(trackers)/diaper.test.tsx
@@ -5,14 +5,12 @@ import { router } from "expo-router";
 import DiaperModule from "@/components/diaper-module";
 import { field, formatStringList, saveLog } from "@/library/log-functions";
 
-jest.mock("expo-router", () => {
-    const replace = jest.fn();
-    return ({
-        router: {
-            replace: replace,
-        },
-    });
-});
+
+jest.mock("expo-router", () => ({
+    router: {
+        dismissTo: jest.fn(),
+    },
+}));
 
 jest.mock("react-native", () => {
     const module = jest.requireActual("react-native");
@@ -75,7 +73,7 @@ describe("Track diaper screen", () => {
         (Alert.alert as jest.Mock).mockClear();
         jest.spyOn(console, "error").mockClear();
         (DiaperModule as jest.Mock).mockClear();
-        (router.replace as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
         (saveLog as jest.Mock).mockClear();
     });
 
@@ -186,8 +184,8 @@ describe("Track diaper screen", () => {
         );
 
         // confirm that the expo-router was called to send the user back to the tracker page
-        expect((router.replace as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
-        expect((router.replace as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((router.dismissTo as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
+        expect((router.dismissTo as jest.Mock)).toHaveBeenCalledTimes(1);
 
         // Alert.alert() called by app/(trackers)/diaper.tsx -> handleSaveDiaperLog()
         expect((Alert.alert as jest.Mock).mock.calls[0][0]).toBe(`Diaper log saved successfully!`);

--- a/test/app/(trackers)/feeding.test.tsx
+++ b/test/app/(trackers)/feeding.test.tsx
@@ -6,14 +6,11 @@ import FeedingCategory, { FeedingCategoryList } from '@/components/feeding-categ
 import { field, formatStringList, saveLog } from "@/library/log-functions";
 
 
-jest.mock("expo-router", () => {
-    const replace = jest.fn();
-    return ({
-        router: {
-            replace: replace,
-        },
-    });
-});
+jest.mock("expo-router", () => ({
+    router: {
+        dismissTo: jest.fn(),
+    },
+}));
 
 jest.mock("react-native", () => {
     const module = jest.requireActual("react-native");
@@ -102,7 +99,7 @@ describe("Track feeding screen", () => {
     beforeEach(() => {
         // to clear the .mock.calls array for each
         (Alert.alert as jest.Mock).mockClear();
-        (router.replace as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
         jest.spyOn(console, "error").mockClear();
         (FeedingCategory as jest.Mock).mockClear();
         (saveLog as jest.Mock).mockClear();
@@ -241,8 +238,8 @@ describe("Track feeding screen", () => {
         );
 
         // confirm that the expo-router was called to send the user back to the tracker page
-        expect((router.replace as jest.Mock).mock.calls[0][0]).toBe(`/(tabs)`);
-        expect((router.replace as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((router.dismissTo as jest.Mock).mock.calls[0][0]).toBe(`/(tabs)`);
+        expect((router.dismissTo as jest.Mock)).toHaveBeenCalledTimes(1);
 
         // Alert.alert() called by app/(trackers)/feeding.tsx -> handleSaveFeedingLog()
         expect((Alert.alert as jest.Mock).mock.calls[0][0]).toBe(`Feeding log saved successfully!`);

--- a/test/app/(trackers)/health.test.tsx
+++ b/test/app/(trackers)/health.test.tsx
@@ -5,9 +5,10 @@ import { router } from "expo-router";
 import HealthModule, { HealthCategory } from "@/components/health-module";
 import { field, formatStringList, saveLog } from "@/library/log-functions";
 
+
 jest.mock("expo-router", () => ({
     router: {
-        replace: jest.fn(),
+        dismissTo: jest.fn(),
     },
 }));
 
@@ -106,7 +107,7 @@ describe("Track health screen", () => {
         (HealthModule as jest.Mock).mockClear();
         (Alert.alert as jest.Mock).mockClear();
         jest.spyOn(console, "error").mockClear();
-        (router.replace as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
         (saveLog as jest.Mock).mockClear();
     });
 
@@ -240,8 +241,8 @@ describe("Track health screen", () => {
         );
 
         // confirm that the expo-router was called to send the user back to the tracker page
-        expect((router.replace as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
-        expect((router.replace as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((router.dismissTo as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
+        expect((router.dismissTo as jest.Mock)).toHaveBeenCalledTimes(1);
 
         // Alert.alert() called by app/(trackers)/health.tsx -> handleSaveHealthLog()
         expect((Alert.alert as jest.Mock).mock.calls[0][0]).toBe(`Success`);

--- a/test/app/(trackers)/milestone.test.tsx
+++ b/test/app/(trackers)/milestone.test.tsx
@@ -31,14 +31,11 @@ jest.mock("expo-image-picker", () => ({
     launchImageLibraryAsync: jest.fn(),
 }));
 
-jest.mock("expo-router", () => {
-    const replace = jest.fn();
-    return ({
-        router: {
-            replace: replace,
-        },
-    });
-});
+jest.mock("expo-router", () => ({
+    router: {
+        dismissTo: jest.fn(),
+    },
+}));
 
 jest.mock("react-native", () => {
     const module = jest.requireActual("react-native");
@@ -127,7 +124,7 @@ describe("Track milestone screen", () => {
         (CategoryModule as jest.Mock).mockClear();
         (DateTimePicker as jest.Mock).mockClear();
         (DateTimePickerAndroid.open as jest.Mock).mockClear();
-        (router.replace as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
         (saveLog as jest.Mock).mockClear();
     });
 
@@ -318,8 +315,8 @@ describe("Track milestone screen", () => {
         );
 
         // confirm that the expo-router was called to send the user back to the tracker page
-        expect((router.replace as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
-        expect((router.replace as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((router.dismissTo as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
+        expect((router.dismissTo as jest.Mock)).toHaveBeenCalledTimes(1);
 
         // Alert.alert() called by app/(trackers)/milestone.tsx -> handleSaveMilestoneLog()
         expect((Alert.alert as jest.Mock).mock.calls[0][0]).toBe(`Milestone log saved successfully!`);

--- a/test/app/(trackers)/nursing.test.tsx
+++ b/test/app/(trackers)/nursing.test.tsx
@@ -6,14 +6,11 @@ import NursingStopwatch from "@/components/nursing-stopwatch";
 import { field, saveLog } from "@/library/log-functions";
 
 
-jest.mock("expo-router", () => {
-    const replace = jest.fn();
-    return {
-        router: {
-            replace: replace,
-        },
-    };
-});
+jest.mock("expo-router", () => ({
+    router: {
+        dismissTo: jest.fn(),
+    },
+}));
 
 jest.mock("react-native", () => {
     const module = jest.requireActual("react-native");
@@ -99,6 +96,7 @@ describe("Track nursing screen", () => {
         (NursingStopwatch as jest.Mock).mockClear();
         jest.spyOn(console, "error").mockClear();
         (saveLog as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
     });
 
     test("Renders nursing tracking inputs", () => {
@@ -203,8 +201,8 @@ describe("Track nursing screen", () => {
         );
 
         // confirm that the expo-router was called to send the user back to the tracker page
-        expect((router.replace as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
-        expect((router.replace as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((router.dismissTo as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
+        expect((router.dismissTo as jest.Mock)).toHaveBeenCalledTimes(1);
 
         // Alert.alert() called by app/(trackers)/nursing.tsx -> handleSaveNursingLog()
         expect((Alert.alert as jest.Mock).mock.calls[0][0]).toBe(`Nursing log saved successfully!`);

--- a/test/app/(trackers)/sleep.test.tsx
+++ b/test/app/(trackers)/sleep.test.tsx
@@ -6,9 +6,10 @@ import Stopwatch from "@/components/stopwatch";
 import ManualEntry from "@/components/sleep-manual-entry";
 import { field, saveLog } from "@/library/log-functions";
 
+
 jest.mock("expo-router", () => ({
     router: {
-        replace: jest.fn(),
+        dismissTo: jest.fn(),
     },
 }));
 
@@ -93,6 +94,7 @@ describe("Track sleep screen", () => {
         (Stopwatch as jest.Mock).mockClear();
         (ManualEntry as jest.Mock).mockClear();
         (saveLog as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
     });
 
     test("Renders sleep tracking inputs", () => {
@@ -194,8 +196,8 @@ describe("Track sleep screen", () => {
         expect((Alert.alert as jest.Mock).mock.calls[0][0]).toBe("Sleep log saved successfully!");
 
         // confirm that the expo-router was called to send the user back to the tracker page
-        expect((router.replace as jest.Mock)).toHaveBeenCalledTimes(1);
-        expect((router.replace as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
+        expect((router.dismissTo as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((router.dismissTo as jest.Mock)).toHaveBeenLastCalledWith("/(tabs)");
     });
 
     test("Saves correct values (stopwatch)", async () => {


### PR DESCRIPTION
# What
- Changed `router.replace()` calls after saving logs to `router.dismissTo()`, to prevent excess pages placed on the routing stack
- Updated unit tests to match

# Look
- N/A

# How to Test
- Check out this branch
- Run the app using expo
- Save several new logs in a row
- Navigate back (ie, using the android back button)
- The user should be sent to a different page than the tracker home page  

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-231)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 