### PR TITLE
KAN-245/Sign up missing fields

### DIFF
--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -14,6 +14,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '@/components/button';
 import { useAuth } from '@/library/auth-provider';
+import { formatStringList } from '@/library/log-functions';
 
 const SignUpScreen: React.FC = () => {
     const [email, setEmail] = React.useState('');
@@ -29,19 +30,16 @@ const SignUpScreen: React.FC = () => {
 
     const handleSignUp = async () => {
         // Validate that all fields are filled in
-        if (
-            !email ||
-            !firstName ||
-            !lastName ||
-            !password ||
-            !confirmPassword
-        ) {
-            Alert.alert('All fields are required.');
-            return;
-        }
+		const missingFields = [];
+		if (!email.trim()) missingFields.push("email");
+		if (!firstName.trim()) missingFields.push("first name");
+		if (!lastName.trim()) missingFields.push("last name");
+		if (!password.trim()) missingFields.push("password");
+		else if (!confirmPassword.trim()) missingFields.push("confirmed password");
 
-        if (firstName.trim().length === 0 || lastName.trim().length === 0) {
-            Alert.alert("Please enter a valid name!");
+        if (missingFields.length > 0) {
+            const formattedMissing = formatStringList(missingFields);
+            Alert.alert('All fields are required.', `Please provide the following fields: ${formattedMissing}.`);
             return;
         }
 
@@ -70,7 +68,6 @@ const SignUpScreen: React.FC = () => {
                 }
             } else {
                 // if successful, sign in automatically
-                setLoading(true);
                 const response = await signIn(email, password);
                 setLoading(false);
                 if (response.error) {

--- a/test/app/(auth)/signup.test.tsx
+++ b/test/app/(auth)/signup.test.tsx
@@ -14,6 +14,8 @@ jest.mock("@/library/auth-provider", () => ({
   }),
 }));
 
+jest.mock("@/library/log-functions", () => ({}));
+
 
 describe("Create Account screen", () => {
     test("Render input fields", () => {


### PR DESCRIPTION
# What
- Added more specific error message for missing fields on sign up
- Removed redundant `setLoading()` call in signup page

# Look
<img width="210" height="490" alt="image" src="https://github.com/user-attachments/assets/00bd40fb-3c12-4941-af3f-ad23acc5fea1" />

# How to Test
- Check out this branch
- Run the app using expo
- Attempt to create a new account without all required fields filled in
- The error message should specify which fields are missing

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-245)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
