### PR TITLE
Added note entry and updated unit tests

### DIFF
--- a/app/(trackers)/diaper.tsx
+++ b/app/(trackers)/diaper.tsx
@@ -134,7 +134,7 @@ export default function Diaper() {
 							note={note}
 							setNote={setNote}
 							setIsTyping={setIsTyping}
-							placeholder="e.g. really messy"
+							placeholder={stringLib.uiLabels.diaperNotePlaceholder}
 							testID="diaper-note-entry"
 						/>
 						{/* Action buttons row */}

--- a/app/(trackers)/diaper.tsx
+++ b/app/(trackers)/diaper.tsx
@@ -1,7 +1,6 @@
 import {
 	Text,
 	View,
-	TextInput,
 	TouchableOpacity,
 	TouchableWithoutFeedback,
 	Keyboard,
@@ -15,8 +14,9 @@ import DiaperModule from "@/components/diaper-module";
 import { useAuth } from "@/library/auth-provider";
 import { saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
+import stringLib from "@/assets/stringLibrary.json";
+import NoteEntry from "@/components/note-entry";
 
-import stringLib from "../../assets/stringLibrary.json";
 
 // Diaper.tsx
 // Screen for logging diaper changes — includes selecting consistency, amount, change time, notes, and save logic
@@ -130,26 +130,13 @@ export default function Diaper() {
 							testID={"diaper-main-inputs"}
 						/>
 						{/* Note input section */}
-						<View className='tracker-section'>
-							<View className='tracker-section-label'>
-								<Text className='tracker-section-label-text'>
-									{stringLib.uiLabels.noteLabel}
-								</Text>
-							</View>
-							<View className='ml-4 mr-4 mb-6'>
-								<TextInput
-									className='text-input-note'
-									placeholder="i.e. really messy"
-									multiline={true}
-									maxLength={200}
-									onFocus={() => setIsTyping(true)}
-									onBlur={() => setIsTyping(false)}
-									value={note}
-									onChangeText={setNote}
-									testID="diaper-note-entry"
-								/>
-							</View>
-						</View>
+						<NoteEntry
+							note={note}
+							setNote={setNote}
+							setIsTyping={setIsTyping}
+							placeholder="e.g. really messy"
+							testID="diaper-note-entry"
+						/>
 						{/* Action buttons row */}
 						<View className="flex-row gap-2 pb-5">
 							<TouchableOpacity

--- a/app/(trackers)/feeding.tsx
+++ b/app/(trackers)/feeding.tsx
@@ -1,7 +1,6 @@
 import {
 	Text,
 	View,
-	TextInput,
 	TouchableOpacity,
 	TouchableWithoutFeedback,
 	Keyboard,
@@ -17,8 +16,8 @@ import FeedingCategory, {
 import { useAuth } from "@/library/auth-provider";
 import { saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
-
-import stringLib from "../../assets/stringLibrary.json";
+import stringLib from "@/assets/stringLibrary.json";
+import NoteEntry from "@/components/note-entry";
 
 // Feeding.tsx
 // Screen for logging baby feeding sessions — includes category, item name, amount, feeding time, optional notes, and save logic
@@ -139,26 +138,13 @@ export default function Feeding() {
 							testID="feeding-data-entry"
 						/>
 						{/* Note input section */}
-						<View className='tracker-section'>
-							<View className='tracker-section-label'>
-								<Text className='tracker-section-label-text'>
-									{stringLib.uiLabels.noteLabel}
-								</Text>
-							</View>
-							<View className='ml-4 mr-4 mb-6'>
-								<TextInput
-									className='text-input-note'
-									placeholder="i.e. does not like pureed carrots"
-									multiline={true}
-									maxLength={200}
-									onFocus={() => setIsTyping(true)}
-									onBlur={() => setIsTyping(false)}
-									value={note}
-									onChangeText={setNote}
-									testID="feeding-note-entry"
-								/>
-							</View>
-						</View>
+						<NoteEntry
+							note={note}
+							setNote={setNote}
+							setIsTyping={setIsTyping}
+							placeholder="e.g. does not like pureed carrots"
+							testID="feeding-note-entry"
+						/>
 						{/* Action buttons for saving and resetting form */}
 						<View className="flex-row gap-2 pb-5">
 							<TouchableOpacity

--- a/app/(trackers)/feeding.tsx
+++ b/app/(trackers)/feeding.tsx
@@ -142,7 +142,7 @@ export default function Feeding() {
 							note={note}
 							setNote={setNote}
 							setIsTyping={setIsTyping}
-							placeholder="e.g. does not like pureed carrots"
+							placeholder={stringLib.uiLabels.feedingNotePlaceholder}
 							testID="feeding-note-entry"
 						/>
 						{/* Action buttons for saving and resetting form */}

--- a/app/(trackers)/health.tsx
+++ b/app/(trackers)/health.tsx
@@ -297,13 +297,13 @@ export default function Health() {
 							}))
 						}
 						setIsTyping={setIsTyping}
-						placeholder={`e.g. ${
-							healthLog.category === "Growth" ? "growth is steady" :
-							healthLog.category === "Activity" ? "enjoyed tummy time" :
-							healthLog.category === "Meds" ? "took medicine without fuss" :
-							healthLog.category === "Vaccine" ? "was fussier for a day" :
-							"realignment surgery for fracture"
-						}`}
+						placeholder={
+							healthLog.category === "Growth" ? stringLib.uiLabels.healthGrowthNotePlaceholder :
+							healthLog.category === "Activity" ? stringLib.uiLabels.healthActivityNotePlaceholder :
+							healthLog.category === "Meds" ? stringLib.uiLabels.healthMedsNotePlaceholder :
+							healthLog.category === "Vaccine" ? stringLib.uiLabels.healthVaccineNotePlaceholder :
+							stringLib.uiLabels.healthOtherNotePlaceholder
+						}
 						testID="health-note-entry"
 					/>
 

--- a/app/(trackers)/health.tsx
+++ b/app/(trackers)/health.tsx
@@ -13,7 +13,6 @@ import {
 	Keyboard,
 	ScrollView,
 	Text,
-	TextInput,
 	TouchableOpacity,
 	TouchableWithoutFeedback,
 	View,
@@ -22,7 +21,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuth } from "@/library/auth-provider";
 import { field, saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
-import stringLib from "../../assets/stringLibrary.json";
+import stringLib from "@/assets/stringLibrary.json";
+import NoteEntry from "@/components/note-entry";
 
 // Define the shape of the health log data object with varying nested properties
 type HealthLog = {
@@ -288,37 +288,24 @@ export default function Health() {
 						testID="health-main-inputs"
 					/>
 					{/* Multiline input for additional notes */}
-					<View className='tracker-section'>
-						<View className='tracker-section-label'>
-							<Text className='tracker-section-label-text'>
-								{stringLib.uiLabels.noteLabel}
-							</Text>
-						</View>
-						<View className='ml-4 mr-4 mb-6'>
-							<TextInput
-								className='text-input-note'
-								placeholder={`i.e. ${
-									healthLog.category === "Growth"
-										? "growth is steady"
-										: healthLog.category === "Activity"
-											? "enjoyed tummy time"
-											: "took medicine without fuss"
-								}`}
-								multiline={true}
-								maxLength={200}
-								onFocus={() => setIsTyping(true)}
-								onBlur={() => setIsTyping(false)}
-								value={healthLog.note}
-								onChangeText={(note) =>
-									setHealthLog((prev) => ({
-										...prev,
-										note,
-									}))
-								}
-								testID="health-note-entry"
-							/>
-						</View>
-					</View>
+					<NoteEntry
+						note={healthLog.note}
+						setNote={(note) =>
+							setHealthLog((prev) => ({
+								...prev,
+								note,
+							}))
+						}
+						setIsTyping={setIsTyping}
+						placeholder={`e.g. ${
+							healthLog.category === "Growth" ? "growth is steady" :
+							healthLog.category === "Activity" ? "enjoyed tummy time" :
+							healthLog.category === "Meds" ? "took medicine without fuss" :
+							healthLog.category === "Vaccine" ? "was fussier for a day" :
+							"realignment surgery for fracture"
+						}`}
+						testID="health-note-entry"
+					/>
 
 					{/* Action buttons to save or reset form */}
 					<View className="flex-row gap-2 pb-5 pt-3">

--- a/app/(trackers)/milestone.tsx
+++ b/app/(trackers)/milestone.tsx
@@ -307,7 +307,7 @@ export default function Milestone() {
 							note={note}
 							setNote={setNote}
 							setIsTyping={setIsTyping}
-							placeholder="e.g., took first steps from the table"
+							placeholder={stringLib.uiLabels.milestoneNotePlaceholder}
 							testID="milestone-note-entry"
 						/>
 

--- a/app/(trackers)/milestone.tsx
+++ b/app/(trackers)/milestone.tsx
@@ -21,8 +21,8 @@ import CategoryModule from "@/components/category-module";
 import { useAuth } from "@/library/auth-provider";
 import { field, saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
-
-import stringLib from "../../assets/stringLibrary.json";
+import stringLib from "@/assets/stringLibrary.json";
+import NoteEntry from "@/components/note-entry";
 
 type MilestoneCategoryList = 'Motor' | 'Language' | 'Social' | 'Cognitive' | 'Other';
 
@@ -303,26 +303,13 @@ export default function Milestone() {
 						</View>
 
 						{/* Note input section */}
-						<View className='tracker-section'>
-							<View className='tracker-section-label'>
-								<Text className='tracker-section-label-text'>
-									{stringLib.uiLabels.noteLabel}
-								</Text>
-							</View>
-							<View className='ml-4 mr-4 mb-6'>
-								<TextInput
-									className='text-input-note'
-									placeholder="e.g., took first steps from the table"
-									multiline={true}
-									maxLength={200}
-									onFocus={() => setIsTyping(true)}
-									onBlur={() => setIsTyping(false)}
-									value={note}
-									onChangeText={setNote}
-									testID="milestone-note-entry"
-								/>
-							</View>
-						</View>
+						<NoteEntry
+							note={note}
+							setNote={setNote}
+							setIsTyping={setIsTyping}
+							placeholder="e.g., took first steps from the table"
+							testID="milestone-note-entry"
+						/>
 
 						<View className="flex-row gap-2">
 							<TouchableOpacity

--- a/app/(trackers)/nursing.tsx
+++ b/app/(trackers)/nursing.tsx
@@ -178,7 +178,7 @@ export default function Nursing() {
 							note={note}
 							setNote={setNote}
 							setIsTyping={setIsTyping}
-							placeholder="e.g. difficulties with latching or signs of poor latching"
+							placeholder={stringLib.uiLabels.nursingNotePlaceholder}
 							testID="nursing-note-entry"
 						/>
 						{/* Bottom Buttons */}

--- a/app/(trackers)/nursing.tsx
+++ b/app/(trackers)/nursing.tsx
@@ -14,8 +14,8 @@ import { router } from "expo-router";
 import NursingStopwatch from "@/components/nursing-stopwatch";
 import { useAuth } from "@/library/auth-provider";
 import { saveLog } from "@/library/log-functions";
-
-import stringLib from "../../assets/stringLibrary.json";
+import stringLib from "@/assets/stringLibrary.json";
+import NoteEntry from "@/components/note-entry";
 
 // nursing.tsx
 // Screen for logging breastfeeding sessions — includes stopwatch, volume input, and notes
@@ -174,26 +174,13 @@ export default function Nursing() {
 							</View>
 						</View>
 						{/* Note Input Section */}
-						<View className='tracker-section'>
-							<View className='tracker-section-label'>
-								<Text className='tracker-section-label-text'>
-									{stringLib.uiLabels.noteLabel}
-								</Text>
-							</View>
-							<View className='ml-4 mr-4 mb-6'>
-								<TextInput
-									className='text-input-note'
-									placeholder="i.e. difficulties with latching or signs of poor latching"
-									multiline={true}
-									maxLength={200}
-									onFocus={() => setIsTyping(true)}
-									onBlur={() => setIsTyping(false)}
-									value={note}
-									onChangeText={setNote}
-									testID="nursing-note-entry"
-								/>
-							</View>
-						</View>
+						<NoteEntry
+							note={note}
+							setNote={setNote}
+							setIsTyping={setIsTyping}
+							placeholder="e.g. difficulties with latching or signs of poor latching"
+							testID="nursing-note-entry"
+						/>
 						{/* Bottom Buttons */}
 						<View className="flex-row gap-2 pb-5">
 							<TouchableOpacity

--- a/app/(trackers)/sleep.tsx
+++ b/app/(trackers)/sleep.tsx
@@ -1,7 +1,6 @@
 import {
 	Text,
 	View,
-	TextInput,
 	TouchableOpacity,
 	TouchableWithoutFeedback,
 	Keyboard,
@@ -15,8 +14,8 @@ import ManualEntry from "@/components/sleep-manual-entry";
 import { router } from "expo-router";
 import { useAuth } from "@/library/auth-provider";
 import { saveLog } from "@/library/log-functions";
-
-import stringLib from "../../assets/stringLibrary.json";
+import stringLib from "@/assets/stringLibrary.json";
+import NoteEntry from "@/components/note-entry";
 
 // Sleep.tsx
 // Screen for logging baby sleep sessions — includes stopwatch, manual entry, notes, and save logic
@@ -170,26 +169,14 @@ export default function Sleep() {
 						/>
 
 						{/* Note input section */}
-						<View className='tracker-section'>
-							<View className='tracker-section-label'>
-								<Text className='tracker-section-label-text'>
-									{stringLib.uiLabels.noteLabel}
-								</Text>
-							</View>
-							<View className='ml-4 mr-4 mb-6'>
-								<TextInput
-									className='text-input-note'
-									placeholder="i.e. baby was squirming often"
-									multiline={true}
-									maxLength={200}
-									onFocus={() => setIsTyping(true)}
-									onBlur={() => setIsTyping(false)}
-									value={note}
-									onChangeText={setNote}
-									testID="sleep-note-entry"
-								/>
-							</View>
-						</View>
+						<NoteEntry
+							note={note}
+							setNote={setNote}
+							setIsTyping={setIsTyping}
+							placeholder="e.g. baby was squirming often"
+							testID="sleep-note-entry"
+						/>
+
 						{/* Action buttons */}
 						<View className="flex-row gap-2 pb-5">
 							<TouchableOpacity

--- a/app/(trackers)/sleep.tsx
+++ b/app/(trackers)/sleep.tsx
@@ -173,7 +173,7 @@ export default function Sleep() {
 							note={note}
 							setNote={setNote}
 							setIsTyping={setIsTyping}
-							placeholder="e.g. baby was squirming often"
+							placeholder={stringLib.uiLabels.sleepNotePlaceholder}
 							testID="sleep-note-entry"
 						/>
 

--- a/assets/stringLibrary.json
+++ b/assets/stringLibrary.json
@@ -25,7 +25,17 @@
         "iosCloseDateTimePicker": "Done",
         "editPhotoMessage": "Photos cannot be edited/updated yet in this menu. This feature will be added in a later release. For now, please create a new log.",
         "signUpButton": "Sign Up",
-        "signUpButtonLoading": "Signing up..."
+        "signUpButtonLoading": "Signing up...",
+        "diaperNotePlaceholder": "e.g. really messy",
+        "feedingNotePlaceholder": "e.g. does not like pureed carrots",
+        "healthGrowthNotePlaceholder": "e.g. growth is steady",
+        "healthActivityNotePlaceholder": "e.g. enjoyed tummy time",
+        "healthMedsNotePlaceholder": "e.g. took medicine without fuss",
+        "healthVaccineNotePlaceholder": "e.g. was fussier for a day",
+        "healthOtherNotePlaceholder": "e.g. realignment surgery for fracture",
+        "milestoneNotePlaceholder": "e.g., took first steps from the table",
+        "nursingNotePlaceholder": "e.g. difficulties with latching or signs of poor latching",
+        "sleepNotePlaceholder": "e.g. baby was squirming often"
     },
 
     "testIDs": {

--- a/components/note-entry.tsx
+++ b/components/note-entry.tsx
@@ -1,0 +1,43 @@
+import { Text, TextInput, View } from "react-native";
+import stringLib from "@/assets/stringLibrary.json";
+
+
+export default function NoteEntry({
+    note,
+    setNote,
+    setIsTyping,
+    placeholder,
+    testID,
+}: {
+    note: string;
+    setNote: (note: string) => void;
+    setIsTyping?: (state: boolean) => void;
+    placeholder?: string;
+    testID?: string;
+}) {
+    return (
+        <View
+            className='tracker-section'
+            testID={testID}
+        >
+            <View className='tracker-section-label'>
+                <Text className='tracker-section-label-text'>
+                    {stringLib.uiLabels.noteLabel}
+                </Text>
+            </View>
+            <View className='ml-4 mr-4 mb-6'>
+                <TextInput
+                    className='text-input-note'
+                    placeholder={placeholder}
+                    multiline={true}
+                    maxLength={200}
+                    onFocus={() => setIsTyping?.(true)}
+                    onBlur={() => setIsTyping?.(false)}
+                    value={note}
+                    onChangeText={setNote}
+                    testID="text-entry"
+                />
+            </View>
+        </View>
+    );
+}

--- a/test/app/(trackers)/diaper.test.tsx
+++ b/test/app/(trackers)/diaper.test.tsx
@@ -5,6 +5,7 @@ import { router } from "expo-router";
 import DiaperModule from "@/components/diaper-module";
 import { field, saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
+import NoteEntry from "@/components/note-entry";
 
 
 jest.mock("expo-router", () => ({
@@ -21,8 +22,14 @@ jest.mock("react-native", () => {
 
 jest.mock("@/components/diaper-module.tsx", () => {
     const View = jest.requireActual("react-native").View;
-    const DiaperModuleMock = jest.fn(({testID}: {testID?: string}) => (<View testID={testID}></View>));
+    const DiaperModuleMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
     return DiaperModuleMock;
+});
+
+jest.mock("@/components/note-entry.tsx", () => {
+    const View = jest.requireActual("react-native").View;
+    const NoteEntryMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
+    return NoteEntryMock;
 });
 
 jest.mock("@/library/auth-provider", () => ({
@@ -46,26 +53,35 @@ async function setDiaperInputs({
     consistency,
     amount,
     time,
+    note,
 } : {
     consistency?: any;
     amount?: any;
     time?: Date;
+    note?: string;
 }) {
-    // read parameters to first call of DiaperModule
+    // read parameters to most recent call of <DiaperModule/>
     const {
         onConsistencyUpdate,
         onAmountUpdate,
         onTimeUpdate,
-    } = (DiaperModule as jest.Mock).mock.calls[0][0];
+    } = (DiaperModule as jest.Mock).mock.lastCall[0];
 
-    if (consistency != null) {
+    if (consistency !== undefined) {
         await act(() => onConsistencyUpdate?.(consistency));
     }
-    if (amount != null) {
+    if (amount !== undefined) {
         await act(() => onAmountUpdate?.(amount));
     }
-    if (time != null) {
+    if (time !== undefined) {
         await act(() => onTimeUpdate?.(time));
+    }
+
+    // read parameters to most recent call of <NoteEntry/>
+    const { setNote } = (NoteEntry as jest.Mock).mock.lastCall[0];
+
+    if (note !== undefined) {
+        await act(() => setNote?.(note));
     }
 }
 
@@ -100,11 +116,8 @@ describe("Track diaper screen", () => {
         render(<Diaper/>);
 
         // write something in the note entry...
-        await userEvent.type(
-            screen.getByTestId("diaper-note-entry"),
-            testNote
-        );
-        expect(screen.getByDisplayValue(testNote)).toBeTruthy();  // ensure the typed note can be found
+        await setDiaperInputs({ note: testNote });
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe(testNote);  // ensure the typed note can be found
 
         const mainInputs = screen.getByTestId("diaper-main-inputs");  // get the displayed <DiaperModule/>
 
@@ -113,7 +126,7 @@ describe("Track diaper screen", () => {
         );
 
         // ensure note is no longer present
-        expect(() => screen.getByDisplayValue(testNote)).toThrow();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe("");
         // ensure new instance of <DiaperModule/> is being used
         expect(screen.getByTestId("diaper-main-inputs") === mainInputs).toBeFalsy();
     });
@@ -202,13 +215,12 @@ describe("Track diaper screen", () => {
         const testAmount = "test amount";
 
         render(<Diaper/>);
-        await setDiaperInputs({ consistency: testConsistency, amount: testAmount, time: testTime });
-
-        // write a note
-        await userEvent.type(
-            screen.getByTestId("diaper-note-entry"),
-            testNote
-        );
+        await setDiaperInputs({
+            consistency: testConsistency,
+            amount: testAmount,
+            time: testTime,
+            note: testNote,
+        });
 
         // submit log
         await userEvent.press(

--- a/test/app/(trackers)/feeding.test.tsx
+++ b/test/app/(trackers)/feeding.test.tsx
@@ -5,6 +5,7 @@ import { Alert } from "react-native";
 import FeedingCategory, { FeedingCategoryList } from '@/components/feeding-category';
 import { field, saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
+import NoteEntry from "@/components/note-entry";
 
 
 jest.mock("expo-router", () => ({
@@ -33,6 +34,12 @@ jest.mock("@/components/feeding-category.tsx", () => {
         </View>
     ));
     return FeedingCategoryMock;
+});
+
+jest.mock("@/components/note-entry.tsx", () => {
+    const View = jest.requireActual("react-native").View;
+    const NoteEntryMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
+    return NoteEntryMock;
 });
 
 jest.mock("@/library/auth-provider", () => ({
@@ -88,12 +95,11 @@ async function setFeedingInputs({
         await act(() => onTimeUpdate?.(time));
     }
 
-    // type into <TextInput/> components for note
-    if (note != null) {
-        await userEvent.type(
-            screen.getByTestId("feeding-note-entry"),
-            note
-        );
+    // read parameters to most recent call of <NoteEntry/>
+    const { setNote } = (NoteEntry as jest.Mock).mock.lastCall[0];
+
+    if (note !== undefined) {
+        await act(() => setNote?.(note));
     }
 }
 
@@ -143,7 +149,7 @@ describe("Track feeding screen", () => {
         expect(screen.getByDisplayValue(testCategory)).toBeTruthy();
         expect(screen.getByDisplayValue(testName)).toBeTruthy();
         expect(screen.getByDisplayValue(testAmount)).toBeTruthy();
-        expect(screen.getByDisplayValue(testNote)).toBeTruthy();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe(testNote);
 
         await userEvent.press(screen.getByTestId("feeding-reset-form-button"));
 
@@ -151,7 +157,7 @@ describe("Track feeding screen", () => {
         expect(screen.queryByDisplayValue(testCategory)).toBeNull();
         expect(screen.queryByDisplayValue(testName)).toBeNull();
         expect(screen.queryByDisplayValue(testAmount)).toBeNull();
-        expect(screen.queryByDisplayValue(testNote)).toBeNull();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe("");
     });
     
     test("Catch unfilled inputs", async () => {

--- a/test/app/(trackers)/health.test.tsx
+++ b/test/app/(trackers)/health.test.tsx
@@ -5,6 +5,7 @@ import { router } from "expo-router";
 import HealthModule, { HealthCategory } from "@/components/health-module";
 import { field, saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
+import NoteEntry from "@/components/note-entry";
 
 
 jest.mock("expo-router", () => ({
@@ -21,8 +22,14 @@ jest.mock("react-native", () => {
 
 jest.mock("@/components/health-module.tsx", () => {
     const View = jest.requireActual("react-native").View;
-    const HealthModuleMock = jest.fn(({testID}: {testID?: string}) => (<View testID={testID}></View>));
+    const HealthModuleMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
     return HealthModuleMock;
+});
+
+jest.mock("@/components/note-entry.tsx", () => {
+    const View = jest.requireActual("react-native").View;
+    const NoteEntryMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
+    return NoteEntryMock;
 });
 
 jest.mock("@/library/auth-provider", () => ({
@@ -96,11 +103,12 @@ async function setHealthInputs({
     if (date) {
         await act(() => onDateUpdate?.(date));
     }
-    if (note) {
-        await userEvent.type(
-            screen.getByTestId("health-note-entry"),
-            note
-        );
+
+    // read parameters to most recent call of <NoteEntry/>
+    const { setNote } = (NoteEntry as jest.Mock).mock.lastCall[0];
+
+    if (note !== undefined) {
+        await act(() => setNote?.(note));
     }
 }
 
@@ -134,11 +142,8 @@ describe("Track health screen", () => {
         render(<Health/>);
 
         // write something in the note entry...
-        await userEvent.type(
-            screen.getByTestId("health-note-entry"),
-            testNote
-        );
-        expect(screen.getByDisplayValue(testNote)).toBeTruthy();  // ensure the typed note can be found
+        await setHealthInputs({ note: testNote });
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe(testNote);  // ensure the typed note can be found
 
         const mainInputs = screen.getByTestId("health-main-inputs");  // get the displayed <HealthModule/>
 
@@ -147,7 +152,7 @@ describe("Track health screen", () => {
         );
 
         // ensure note is no longer present
-        expect(() => screen.getByDisplayValue(testNote)).toThrow();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe("");
         // ensure new instance of <HealthModule/> is being used
         expect(screen.getByTestId("health-main-inputs") === mainInputs).toBeFalsy();
     });

--- a/test/app/(trackers)/milestone.test.tsx
+++ b/test/app/(trackers)/milestone.test.tsx
@@ -7,6 +7,7 @@ import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/d
 import { launchImageLibraryAsync, requestMediaLibraryPermissionsAsync } from "expo-image-picker";
 import { field, saveLog } from "@/library/log-functions";
 import { formatStringList } from "@/library/utils";
+import NoteEntry from "@/components/note-entry";
 
 
 jest.mock("@react-native-community/datetimepicker", () => {
@@ -21,10 +22,16 @@ jest.mock("@react-native-community/datetimepicker", () => {
 jest.mock("@/components/category-module", () => {
     const Text = jest.requireActual("react-native").Text;
     const CategoryModuleMock = jest.fn(
-        ({testID, selectedCategory}: {testID?: string; selectedCategory: string}) =>
+        ({ testID, selectedCategory }: { testID?: string; selectedCategory: string }) =>
             (<Text testID={testID}>{selectedCategory}</Text>)
     );
     return CategoryModuleMock;
+});
+
+jest.mock("@/components/note-entry.tsx", () => {
+    const View = jest.requireActual("react-native").View;
+    const NoteEntryMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
+    return NoteEntryMock;
 });
 
 jest.mock("expo-image-picker", () => ({
@@ -110,11 +117,12 @@ async function setMilestoneInputs({
         );
         await userEvent.press(screen.getByTestId("milestone-photo-button"));  // open photo picker
     }
-    if (note) {
-        await userEvent.type(
-            screen.getByTestId("milestone-note-entry"),
-            note
-        );
+
+    // read parameters to most recent call of <NoteEntry/>
+    const { setNote } = (NoteEntry as jest.Mock).mock.lastCall[0];
+
+    if (note !== undefined) {
+        await act(() => setNote?.(note));
     }
 }
 
@@ -200,7 +208,7 @@ describe("Track milestone screen", () => {
         expect(screen.getByDisplayValue(testName)).toBeTruthy();
         expect(screen.getByText(testTime.toLocaleDateString())).toBeTruthy();
         expect(screen.getByText(`(${testPhotoName})`)).toBeTruthy();
-        expect(screen.getByDisplayValue(testNote)).toBeTruthy();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe(testNote);
 
         // submit log
         await userEvent.press(
@@ -212,7 +220,7 @@ describe("Track milestone screen", () => {
         expect(() => screen.getByDisplayValue(testName)).toThrow();
         expect(() => screen.getByText(testTime.toLocaleDateString())).toThrow();
         expect(() => screen.getByText(testPhotoName)).toThrow();
-        expect(() => screen.getByDisplayValue(testNote)).toThrow();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe("");
     });
             
     test("Catches denied photo permissions", async () => {

--- a/test/app/(trackers)/nursing.test.tsx
+++ b/test/app/(trackers)/nursing.test.tsx
@@ -4,6 +4,7 @@ import { Alert } from "react-native";
 import { router } from "expo-router";
 import NursingStopwatch from "@/components/nursing-stopwatch";
 import { field, saveLog } from "@/library/log-functions";
+import NoteEntry from "@/components/note-entry";
 
 
 jest.mock("expo-router", () => ({
@@ -20,8 +21,14 @@ jest.mock("react-native", () => {
 
 jest.mock("@/components/nursing-stopwatch.tsx", () => {
     const View = jest.requireActual("react-native").View;
-    const NursingStopwatchMock = jest.fn(({testID}: {testID?: string}) => (<View testID={testID}></View>));
+    const NursingStopwatchMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
     return NursingStopwatchMock;
+});
+
+jest.mock("@/components/note-entry.tsx", () => {
+    const View = jest.requireActual("react-native").View;
+    const NoteEntryMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
+    return NoteEntryMock;
 });
 
 jest.mock("@/library/auth-provider", () => ({
@@ -79,11 +86,12 @@ async function setNursingInputs({
             rightAmount
         );
     }
-    if (note) {
-        await userEvent.type(
-            screen.getByTestId("nursing-note-entry"),
-            note
-        );
+
+    // read parameters to most recent call of <NoteEntry/>
+    const { setNote } = (NoteEntry as jest.Mock).mock.lastCall[0];
+
+    if (note !== undefined) {
+        await act(() => setNote?.(note));
     }
 }
 
@@ -120,25 +128,14 @@ describe("Track nursing screen", () => {
         const testRightAmount = "test right";
         render(<Nursing/>);
 
-        // write something in the note entry...
-        await userEvent.type(
-            screen.getByTestId("nursing-note-entry"),
-            testNote
-        );
-        expect(screen.getByDisplayValue(testNote)).toBeTruthy();  // ensure the typed note can be found
-
-        // write left amount...
-        await userEvent.type(
-            screen.getByTestId("nursing-left-amount"),
-            testLeftAmount
-        );
+        // write something in the note entry and amount fields...
+        await setNursingInputs({
+            leftAmount: testLeftAmount,
+            rightAmount: testRightAmount,
+            note: testNote,
+        });
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe(testNote);  // ensure the typed note can be found
         expect(screen.getByDisplayValue(testLeftAmount)).toBeTruthy();  // ensure the typed amount can be found
-
-        // write right amount...
-        await userEvent.type(
-            screen.getByTestId("nursing-right-amount"),
-            testRightAmount
-        );
         expect(screen.getByDisplayValue(testRightAmount)).toBeTruthy();  // ensure the typed amount can be found
 
         const mainInputs = screen.getByTestId("nursing-stopwatch");  // get the displayed <NursingStopwatch/>
@@ -148,7 +145,7 @@ describe("Track nursing screen", () => {
         );
 
         // ensure note is no longer present
-        expect(() => screen.getByDisplayValue(testNote)).toThrow();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe("");
         // ensure left and right amounts are no longer present
         expect(() => screen.getByDisplayValue(testLeftAmount)).toThrow();
         expect(() => screen.getByDisplayValue(testRightAmount)).toThrow();

--- a/test/app/(trackers)/sleep.test.tsx
+++ b/test/app/(trackers)/sleep.test.tsx
@@ -5,6 +5,7 @@ import { router } from "expo-router";
 import Stopwatch from "@/components/stopwatch";
 import ManualEntry from "@/components/sleep-manual-entry";
 import { field, saveLog } from "@/library/log-functions";
+import NoteEntry from "@/components/note-entry";
 
 
 jest.mock("expo-router", () => ({
@@ -21,8 +22,14 @@ jest.mock("react-native", () => {
 
 jest.mock("@/components/stopwatch.tsx", () => {
     const View = jest.requireActual("react-native").View;
-    const SleepStopwatchMock = jest.fn(({testID}: {testID?: string}) => (<View testID={testID}></View>));
+    const SleepStopwatchMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
     return SleepStopwatchMock;
+});
+
+jest.mock("@/components/note-entry.tsx", () => {
+    const View = jest.requireActual("react-native").View;
+    const NoteEntryMock = jest.fn(({ testID }: { testID?: string }) => (<View testID={testID}></View>));
+    return NoteEntryMock;
 });
 
 jest.mock("@/components/sleep-manual-entry.tsx", () => {
@@ -75,12 +82,11 @@ async function setSleepInputs({
         await act(() => onDatesUpdate?.(startDate, endDate));
     }
 
-    // type into <TextInput/> component for note
-    if (note) {
-        await userEvent.type(
-            screen.getByTestId("sleep-note-entry"),
-            note
-        );
+    // read parameters to most recent call of <NoteEntry/>
+    const { setNote } = (NoteEntry as jest.Mock).mock.lastCall[0];
+
+    if (note !== undefined) {
+        await act(() => setNote?.(note));
     }
 }
 
@@ -146,7 +152,7 @@ describe("Track sleep screen", () => {
 
         // write something in the note entry...
         await setSleepInputs({ note: testNote });
-        expect(screen.getByDisplayValue(testNote)).toBeTruthy();  // ensure the typed note can be found
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe(testNote);  // ensure the typed note can be found
 
         const stopwatch = screen.getByTestId("sleep-stopwatch");  // get the displayed <Stopwatch/>
         const manualEntry = screen.getByTestId("sleep-manual-time-entry");  // get the displayed <ManualEntry/>
@@ -156,7 +162,7 @@ describe("Track sleep screen", () => {
         );
 
         // ensure note is no longer present
-        expect(() => screen.getByDisplayValue(testNote)).toThrow();
+        expect((NoteEntry as jest.Mock).mock.lastCall[0].note).toBe("");
         // ensure new instance of <Stopwatch/> is being used
         expect(screen.getByTestId("sleep-stopwatch") === stopwatch).toBeFalsy();
         // ensure new instance of <ManualEntry/> is being used

--- a/test/components/note-entry.test.tsx
+++ b/test/components/note-entry.test.tsx
@@ -1,0 +1,71 @@
+import NoteEntry from "@/components/note-entry";
+import { render, screen, userEvent } from "@testing-library/react-native";
+import stringLib from "@/assets/stringLibrary.json";
+
+
+
+describe("Component <NoteEntry/>", () => {
+
+    test("Renders labels", () => {
+        const testPlaceholder = "test placeholder";
+        render(<NoteEntry
+            note=""
+            placeholder={testPlaceholder}
+            setNote={() => null}
+        />);
+
+        expect(screen.getByText(stringLib.uiLabels.noteLabel)).toBeTruthy();
+        expect(screen.getByPlaceholderText(testPlaceholder)).toBeTruthy();
+    });
+
+    test("Renders note", () => {
+        const testNote = "test note";
+        render(<NoteEntry
+            note={testNote}
+            setNote={() => null}
+        />);
+
+        expect(screen.getByDisplayValue(testNote)).toBeTruthy();
+    });
+
+    test("Updates note", async () => {
+        const testNote = "test note";
+        const setNote = jest.fn();
+        const { rerender } = render(<NoteEntry
+            note=""
+            setNote={setNote}
+        />);
+
+        // update the note prop when setNote called
+        setNote.mockImplementation(newNote => rerender(
+            <NoteEntry
+                note={newNote}
+                setNote={setNote}
+            />
+        ));
+
+        await userEvent.type(
+            screen.getByTestId("text-entry"),
+            testNote
+        );
+
+        expect(setNote.mock.lastCall[0]).toBe(testNote);
+    });
+
+    test("Sets focus state", async () => {
+        const setIsTyping = jest.fn();
+        render(<NoteEntry
+            note=""
+            setNote={() => null}
+            setIsTyping={setIsTyping}
+        />);
+
+        await userEvent.type(
+            screen.getByTestId("text-entry"),
+            "x"
+        );
+
+        expect(setIsTyping.mock.calls.find(call => call[0])).toBeTruthy();  // contains at least one call with true
+        expect(setIsTyping.mock.lastCall[0]).toBe(false);  // most recent call is false
+    });
+});


### PR DESCRIPTION
# What
- Added `<NoteEntry/>` component for tracker pages
- Updated tracker unit tests to mock out new `<NoteEntry/>` component
- Added unit tests for new `<NoteEntry/>` component
- Added unique placeholders for the "vaccine" and "other" categories of the health note entry
- Replaced instances of "i.e." with "e.g." in note entry placeholders
- Added stringLib values for note placeholders
- Updated stringLib imports in tracker pages to use absolute imports

# Look
Tests:
<img width="762" height="417" alt="image" src="https://github.com/user-attachments/assets/27e26b64-b7ac-46f0-a2d4-285e3ddbceca" />

# How to Test
- Check out this branch
- Run the app using expo
- Ensure that notes can be saved for each log type as expected
- Ensure that "vaccine" and "other" health log note entries have unique placeholders
- To run unit tests, run `npx jest note trackers`

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-253)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
