### PR TITLE
updated splash screen/log out routing and unit tests

### DIFF
--- a/app/(modals)/profile.tsx
+++ b/app/(modals)/profile.tsx
@@ -55,13 +55,13 @@ export default function Profile() {
                 await exitGuest();
 
                 // Send them back to auth entry
-                router.replace("/");
+                router.dismissTo("/");
             } else {
                 // Signed-in session sign-out: Supabase sign out
                 const { error } = await supabase.auth.signOut();
 
                 if (error) throw error;
-                router.replace("/");
+                router.dismissTo("/");
             }
         } catch (e: any) {
             Alert.alert("Sign out failed", e?.message ?? "Please try again.");

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -38,10 +38,10 @@ export default function RootIndex() {
 	// Navigation handlers for auth routes
 	const { width } = Dimensions.get("window");
 	const handleSignIn = () => {
-		return router.replace("/(auth)/signin");
+		return router.push("/(auth)/signin");
 	};
 	const handleSignUp = () => {
-		return router.replace("/(auth)/signup");
+		return router.push("/(auth)/signup");
 	};
 	const handleGuest = async () => {
 		return router.push("/(auth)/guest");

--- a/test/app/(modals)/profile.test.tsx
+++ b/test/app/(modals)/profile.test.tsx
@@ -16,7 +16,7 @@ const testIDs = stringLib.testIDs.profile;
 
 jest.mock("expo-router", () => ({
     router: {
-        replace: jest.fn(),
+        dismissTo: jest.fn(),
         push: jest.fn(),
     },
 }));
@@ -114,7 +114,7 @@ function manualPromise(): {
 describe("Profile screen", () => {
     beforeEach(() => {
         // to clear the .mock.calls array
-        (router.replace as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
         (Alert.alert as jest.Mock).mockClear();
         (AddChildPopup as jest.Mock).mockClear();
         (SwitchChildPopup as jest.Mock).mockClear();
@@ -215,7 +215,7 @@ describe("Profile screen", () => {
         await userEvent.press(screen.getByTestId(testIDs.signOutButton));
 
         expect(Alert.alert as jest.Mock).toHaveBeenLastCalledWith("Sign out failed", testErrorMessage);
-        expect(router.replace as jest.Mock).toHaveBeenCalledTimes(0);  // user was not redirected
+        expect(router.dismissTo as jest.Mock).toHaveBeenCalledTimes(0);  // user was not redirected
     });
 
     test("Redirects on successful sign out", async () => {
@@ -224,8 +224,8 @@ describe("Profile screen", () => {
 
         await userEvent.press(screen.getByTestId(testIDs.signOutButton));
 
-        expect(router.replace as jest.Mock).toHaveBeenCalledTimes(1);  // user was redirected
-        expect(router.replace as jest.Mock).toHaveBeenLastCalledWith("/");
+        expect(router.dismissTo as jest.Mock).toHaveBeenCalledTimes(1);  // user was redirected
+        expect(router.dismissTo as jest.Mock).toHaveBeenLastCalledWith("/");
     });
 
     test("Displays loading message for child names/switching", async () => {
@@ -659,7 +659,7 @@ describe("profile screen (guest mode)", () => {
     
     beforeEach(() => {
         // to clear the .mock.calls array
-        (router.replace as jest.Mock).mockClear();
+        (router.dismissTo as jest.Mock).mockClear();
         (Alert.alert as jest.Mock).mockClear();
         (AddChildPopup as jest.Mock).mockClear();
         (SwitchChildPopup as jest.Mock).mockClear();
@@ -761,7 +761,7 @@ describe("profile screen (guest mode)", () => {
 
         await userEvent.press(screen.getByTestId(testIDs.signOutButton));
 
-        expect(router.replace as jest.Mock).toHaveBeenCalledTimes(1);  // user was redirected
-        expect(router.replace as jest.Mock).toHaveBeenLastCalledWith("/");
+        expect(router.dismissTo as jest.Mock).toHaveBeenCalledTimes(1);  // user was redirected
+        expect(router.dismissTo as jest.Mock).toHaveBeenLastCalledWith("/");
     });
 });

--- a/test/app/index.test.tsx
+++ b/test/app/index.test.tsx
@@ -1,34 +1,68 @@
 import React from "react";
-import { render, screen } from "@testing-library/react-native";
+import { render, screen, userEvent } from "@testing-library/react-native";
 import RootIndex from "@/app/index";
+import { router } from "expo-router";
 
 jest.mock("expo-router", () => ({
-  router: {
-    replace: jest.fn(),
-  },
+    router: {
+        push: jest.fn(),
+    },
 }));
 
 jest.mock("@/library/auth-provider", () => ({
-  useAuth: () => ({
-    session: null,
-    loading: false,
-  }),
+    useAuth: () => ({
+        session: null,
+        loading: false,
+    }),
 }));
 
 jest.mock("expo-crypto", () => ({}));
 
 describe("Login screen", () => {
+
+    beforeEach(() => {
+        // to clear the .mock.calls array
+        (router.push as jest.Mock).mockClear();
+    });
+
     test("Renders app logo", () => {
       render(<RootIndex/>);
 
       expect(screen.getByTestId("simple-baby-logo")).toBeTruthy();
     });
-  
+
     test("Renders login buttons", () => {
         render(<RootIndex/>);
 
         expect(screen.getByTestId("sign-in-button")).toBeTruthy();
         expect(screen.getByTestId("sign-up-button")).toBeTruthy();
         expect(screen.getByTestId("guest-button")).toBeTruthy();
+    });
+
+    test("Redirects to sign in screen", async () => {
+        render(<RootIndex/>);
+
+        await userEvent.press(screen.getByTestId("sign-in-button"));
+
+        expect(router.push).toHaveBeenCalledTimes(1);
+        expect((router.push as jest.Mock).mock.calls[0][0]).toBe("/(auth)/signin");
+    });
+
+    test("Redirects to sign up screen", async () => {
+        render(<RootIndex/>);
+
+        await userEvent.press(screen.getByTestId("sign-up-button"));
+
+        expect(router.push).toHaveBeenCalledTimes(1);
+        expect((router.push as jest.Mock).mock.calls[0][0]).toBe("/(auth)/signup");
+    });
+
+    test("Redirects to guest screen", async () => {
+        render(<RootIndex/>);
+
+        await userEvent.press(screen.getByTestId("guest-button"));
+
+        expect(router.push).toHaveBeenCalledTimes(1);
+        expect((router.push as jest.Mock).mock.calls[0][0]).toBe("/(auth)/guest");
     });
 });


### PR DESCRIPTION
# What
- Changed "log in" and "sign up" buttons on splash screen to use `router.push()` instead of `router.replace()`
- Changed sign out/exit guest button in profile page to use `router.dismissTo()` instead of `router.replace()`
- Updated existing unit tests, and added unit tests for splash page buttons
- Changed 2 indent spacing to 4 indent spacing in `test/app/index.test.tsx`

# Look
Splash screen navigation:
https://github.com/user-attachments/assets/fe6f9d68-4eac-4ab7-9815-da5ddc20097e
Tests:
<img width="930" height="302" alt="image" src="https://github.com/user-attachments/assets/d01bd771-ccb7-4383-bb11-38e4230bb251" />

# How to Test
- check out this branch using `git checkout bug/navigation`
- run the app using expo
- Ensure that after navigating from the splash screen to the sign in or sign up pages, you can navigate back to the splash screen using the os navigation
- Ensure that signing out/exiting guest mode returns to the splash screen, and that using to os back navigation does not show any screens that should be displayed only for authenticated/guest users
- To run updated unit tests, run `npx jest profile app/index.test.tsx`

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-267)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
