### PR TITLE
MISC: Fix Failing Profile Tests on `main` branch

### DIFF
--- a/test/app/(modals)/profile.test.tsx
+++ b/test/app/(modals)/profile.test.tsx
@@ -748,7 +748,7 @@ describe("profile screen (guest mode)", () => {
         await userEvent.press(screen.getByTestId(testIDs.signOutButton));
 
         expect(Alert.alert as jest.Mock).toHaveBeenLastCalledWith("Sign out failed", testErrorMessage);
-        expect(router.replace as jest.Mock).toHaveBeenCalledTimes(0);  // user was not redirected
+        expect(router.dismissTo as jest.Mock).toHaveBeenCalledTimes(0);  // user was not redirected
 
         // revert library/auth-provider.tsx -> exitGuest to not cause any errors
         updateUseAuth({ exitGuest: async () => undefined});


### PR DESCRIPTION
# What
- Updates router call in `profile.test.tsx` to use `router.dissmissTo()` instead of `router.replace()`
- Previously, this caused failing tests on the main branch that somehow didn't fail when testing previous PRs

# Look
<img width="439" height="255" alt="Screenshot 2026-05-05 at 10 38 02 AM" src="https://github.com/user-attachments/assets/6cbefe91-e619-4414-9a2f-7af9e3d5fc09" />

# How to Test
- Check out this branch
- Run `npx jest`
- Verify that all tests pass

# Jira Ticket
- N/A

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
