### PR TITLE
KAN-270: Fix Discolored Modal Headers

### DIFF
--- a/app/(logs)/_layout.tsx
+++ b/app/(logs)/_layout.tsx
@@ -2,12 +2,26 @@ import { router, Stack } from 'expo-router';
 import {
     Text,
     TouchableOpacity,
+    useColorScheme,
 } from 'react-native';
 
 export default function LogsLayout() {
+    
+    const theme = useColorScheme();
+    const headerStyle = {
+        backgroundColor: theme === 'light' ? '#fff5e4' : '#0b2218',
+    };
+    const headerTitleStyle = {
+        color: theme === 'light' ? '#000' : '#fff',
+    };
+    
     return (
         <Stack
             screenOptions={{
+                headerShown: true,
+                headerStyle: { ...headerStyle },
+                headerTitleStyle: { ...headerTitleStyle, fontWeight: 'bold' },
+                headerShadowVisible: false,
                 headerLeft: () => (
                     <TouchableOpacity
                         onPress={() => {

--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -1,13 +1,25 @@
 import { router, Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { Platform, TouchableOpacity, Text } from 'react-native';
+import { Platform, TouchableOpacity, Text, useColorScheme } from 'react-native';
 
 export default function ModalsLayout() {
+
+    const theme = useColorScheme();
+    const headerStyle = {
+        backgroundColor: theme === 'light' ? '#fff5e4' : '#0b2218',
+    };
+    const headerTitleStyle = {
+        color: theme === 'light' ? '#000' : '#fff',
+    };
+
     return (
         <>
             <StatusBar style={Platform.OS === 'android' ? 'dark' : 'auto'} />
             <Stack screenOptions={{
                 presentation: 'modal',
+                headerShown: true,
+                headerStyle: { ...headerStyle },
+                headerTitleStyle: { ...headerTitleStyle, fontWeight: 'bold' },
                 headerLeft: () => (
                     <TouchableOpacity
                         onPress={() => {


### PR DESCRIPTION
# What
- Fixes discolored headers in dark mode (previously rendered as white, even in dark mode)

# Look
<img width="2412" height="2622" alt="image (20)" src="https://github.com/user-attachments/assets/f522bd6b-2b44-45f1-a557-308862e4f91e" />

# How to Test
- Check out this branch and build the app
- Log in and verify that the headers in the following modals/screens have the proper coloring:
  - Profile Modal
  - Active Child Modal
  - Sleep Logs
  - Nursing Logs
  - Diaper Logs
  - Feeding Logs
  - Milestone Logs
  - Health Logs

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-270)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
