### PR TITLE
KAN-275/Meds Time Taken

### DIFF
--- a/library/log-functions.ts
+++ b/library/log-functions.ts
@@ -288,7 +288,7 @@ export async function fetchLogs<LogType>(
                     async ({ dbFieldName, type }) => [
                         dbFieldName,
                         type === "string" ? await safeDecrypt(entry[dbFieldName])
-                        : type === "date" ? new Date(entry[dbFieldName])
+                        : type === "date" ? (entry[dbFieldName] ? new Date(entry[dbFieldName]) : null) 
                         : entry[dbFieldName]  // don't decrypt "unencrypted" or "photo" fields
                     ]
                 ))


### PR DESCRIPTION
# What
- changed fetchLogs() to return null for date fields if the database field is null. This prevents the time taken field from being displayed for non-meds health logs

# Look
- N/A

# How to Test
- check out this branch
- run the app using expo
- ensure that meds logs display time taken, but other health logs do not
- ensure that other log types display times as expected

# Jira Ticket
[Jira Ticket](https://simple-baby.atlassian.net/browse/KAN-275)

# Self-Reflection Questionnaire?
- Does my code follow the style guidelines of this project?
- Do my changes generate no new warnings or errors?
- Has the documentation been updated (if needed)?
- Have I added new comments when necessary?
- Do new and existing unit tests pass locally with my changes?
- Does my code pass the linter locally with my changes?
- Have I pulled and merged `main` into my branch before committing my changes?
